### PR TITLE
Update to be compatible w/ gcc 4.8.1 and ROOT 5.34

### DIFF
--- a/include/PHCorrelatorBins.h
+++ b/include/PHCorrelatorBins.h
@@ -38,9 +38,9 @@ namespace PHEnergyCorrelator {
     private:
 
       // data members
-      uint32_t            m_num;
       double              m_start;
       double              m_stop;
+      std::size_t         m_num;
       std::vector<double> m_bins;
 
     public:
@@ -48,9 +48,9 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Uniform bin getters
       //-----------------------------------------------------------------------
-      uint32_t GetNum()   const {return m_num;}
-      double   GetStart() const {return m_start;}
-      double   GetStop()  const {return m_stop;}
+      double      GetStart() const {return m_start;}
+      double      GetStop()  const {return m_stop;}
+      std::size_t GetNum()   const {return m_num;}
 
       // ----------------------------------------------------------------------
       //! Variable bin getter
@@ -67,10 +67,10 @@ namespace PHEnergyCorrelator {
       //! ctor accepting uniform parameters
       // ----------------------------------------------------------------------
       Binning(
-        const uint32_t num,
+        const std::size_t num,
         const double start,
         const double stop,
-        const Type::Axis axis = Type::Axis::Norm
+        const Type::Axis axis = Type::Norm
       ) {
 
         m_num   = num;
@@ -107,16 +107,8 @@ namespace PHEnergyCorrelator {
 
     private:
 
-      /* TODO
-       *  - Add cos(angle)
-       *  - Add angle
-       *  - Add xi
-       */
-      std::map<std::string, Binning> m_bins = {
-        { "energy",  {202, -1., 100.} },
-        { "side",    {75, 1e-5, 1., Type::Axis::Log} },
-        { "logside", {75, -5., 0.} }
-      };
+      // data members
+      std::map<std::string, Binning> m_bins;
 
     public:
 
@@ -131,7 +123,7 @@ namespace PHEnergyCorrelator {
         }
 
         // otherwise insert new binning
-        m_bins.insert( {name, binning} );
+        m_bins[name] = binning;
         return;
 
       }  // end 'Add(std::string&, Binning&)'
@@ -168,9 +160,24 @@ namespace PHEnergyCorrelator {
       }  // end 'Get(std::string&)'
 
       // ----------------------------------------------------------------------
-      //! default ctor/dtor
+      //! default ctor
       // ----------------------------------------------------------------------
-      Bins()  {};
+      Bins() {
+
+        /* TODO
+         *  - Add cos(angle)
+         *  - Add angle
+         *  - Add xi
+         */
+        m_bins["energy"]  = Binning(202, -1., 100.);
+        m_bins["side"]    = Binning(75, 1e-5, 1., Type::Log);
+        m_bins["logside"] = Binning(75, -5., 0.);
+
+      }  // end 'ctor()'
+
+      // ----------------------------------------------------------------------
+      //! default dtor
+      // ----------------------------------------------------------------------
       ~Bins() {};
 
   };  // end Bins

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -3,7 +3,7 @@
  *  \authors Derek Anderson, Alex Clarke
  *  \date    09.21.2024
  *
- *  Driver class to run n-point energy-energy correlator
+ *  Cclass to run n-point energy-energy correlator
  *  calculations on inputs.
  */
 /// ============================================================================
@@ -30,9 +30,9 @@ namespace PHEnergyCorrelator {
     private:
 
       // data members
-      std::vector<std::pair<float, float>> m_ptjet_bins;
-      std::vector<std::pair<float, float>> m_cfjet_bins;
-      std::vector<std::pair<float, float>> m_spin_bins;
+      std::vector< std::pair<float, float> > m_ptjet_bins;
+      std::vector< std::pair<float, float> > m_cfjet_bins;
+      std::vector< std::pair<float, float> > m_spin_bins;
 
       /* TODO
        *   - add flags

--- a/include/PHCorrelatorTools.h
+++ b/include/PHCorrelatorTools.h
@@ -31,13 +31,35 @@ namespace PHEnergyCorrelator {
   namespace Tools {
 
     // ------------------------------------------------------------------------
+    //! Wrapper function for std::pow
+    // ------------------------------------------------------------------------
+    double Exponentiate(const double arg) {
+
+      return std::pow(Const::Base(), arg);
+
+    }  // end 'Exponentiate(double&)'
+
+
+
+    // ------------------------------------------------------------------------
+    //! Wrapper function for log
+    // ------------------------------------------------------------------------
+    double Log(const double arg) {
+
+      return std::log10(arg) / std::log10(Const::Base());
+
+    }  // end 'Log(double&)'
+
+
+
+    // ------------------------------------------------------------------------
     //! Divide a range into a certain number of bins
     // ------------------------------------------------------------------------
     std::vector<double> GetBinEdges(
-      const uint32_t num,
+      const std::size_t num,
       const double start,
       const double stop,
-      const Type::Axis axis = Type::Axis::Norm
+      const Type::Axis axis = Type::Log
     ) {
 
       // throw error if start/stop are out of order
@@ -46,8 +68,8 @@ namespace PHEnergyCorrelator {
       if (start > stop) assert(start <= stop);
 
       // set start/stop, calculate bin steps
-      const double start_use = (axis == Type::Axis::Log) ? std::log10(start) : start;
-      const double stop_use  = (axis == Type::Axis::Log) ? std::log10(stop)  : stop;
+      const double start_use = (axis == Type::Log) ? Log(start) : start;
+      const double stop_use  = (axis == Type::Log) ? Log(stop)  : stop;
       const double step      = (stop_use - start_use) / num;
  
       // instantiate vector to hold bins
@@ -55,21 +77,19 @@ namespace PHEnergyCorrelator {
 
       // and fill vector
       double edge = start_use;
-      for (uint32_t inum = 0; inum < num; ++inum) {
+      for (std::size_t inum = 0; inum < num; ++inum) {
         bins.push_back( edge );
         edge += step;
       }
       bins.push_back( edge );
 
       // if need be, transform back from log
-      if (axis == Type::Axis::Log) {
+      if (axis == Type::Log) {
         std::transform(
           bins.begin(),
           bins.end(),
           bins.begin(),
-          [](const double edge) {
-            return std::pow(10., edge);
-          }
+          Exponentiate
         ); 
       }
       return bins;

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -19,7 +19,9 @@ namespace PHEnergyCorrelator {
   // ==========================================================================
   namespace Type {
 
+    // ------------------------------------------------------------------------
     //! Types of binning
+    // -----------------------------------------------------------------------
     enum Axis {Log, Norm};
 
   }  // end Type namespace
@@ -32,7 +34,13 @@ namespace PHEnergyCorrelator {
   /* FIXME might want to move to its own header */
   namespace Const {
 
-    /* TODO fill in */
+    // ------------------------------------------------------------------------
+    //! Base for log axes
+    // ------------------------------------------------------------------------
+    inline double const& Base() {
+       static double base = 10.;
+       return base;
+    }
 
   }   // end Const namespace
 }  // end PHEnergyCorrelator namespace

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -33,10 +33,9 @@ void PHEnergyCorrelatorTest() {
   PHEC::Bins bins;
 
   // loop over R_{L/S/M} bin edges and print them
-  std::size_t iedge = 0;
-  for (const double edge : bins.Get("side").GetBins()) {
-    std::cout << "      --- R_{L}: edge[" << iedge << "] = " << edge << std::endl;
-    ++iedge;
+  const std::vector<double> edges = bins.Get("side").GetBins();
+  for (std::size_t iedge = 0; iedge < edges.size(); ++iedge) {
+    std::cout << "      --- R_{L}: edge[" << iedge << "] = " << edges[iedge] << std::endl;
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
This purges C++11 concepts where needed. The code now compiles and runs in both ROOT 5.34 (w/ gcc 4.8.1) and ROOT 6.28 (w/  gcc 12.1.0.