### PR TITLE
Add Code to Simulation Analysis Macro (and More)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*.d
+*.so
+*.pcm
+*.root
 test/*
 !test/bins.h
 !test/SimStats.h

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -237,7 +237,7 @@ namespace PHEnergyCorrelator {
       void CalcEEC(
         const Type::Jet& jet,
         const std::pair<Type::Cst, Type::Cst>& csts,
-        const double evtweight = 1.
+        const double evtweight = 1.0
       ) {
 
         // get jet 4-momenta

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -230,7 +230,15 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Do EEC calculation
       // ----------------------------------------------------------------------
-      void CalcEEC(const Type::Jet& jet, const std::pair<Type::Cst, Type::Cst>& csts) {
+      /*! Note that the optional third argument, `evtweight` is there
+       *  to allow for weighting by ckin, spin, etc. By default, it's
+       *  set to 1.
+       */ 
+      void CalcEEC(
+        const Type::Jet& jet,
+        const std::pair<Type::Cst, Type::Cst>& csts,
+        const double evtweight = 1.
+      ) {
 
         // get jet 4-momenta
         TLorentzVector jet_vec = Tools::GetJetLorentz(jet);
@@ -249,7 +257,7 @@ namespace PHEnergyCorrelator {
 
         // calculate RL (dist b/n cst.s for EEC) 
         const double dist   = Tools::GetCstDist(csts);
-        const double weight = cst_weights.first * cst_weights.second;
+        const double weight = cst_weights.first * cst_weights.second * evtweight;
 
         // bundle results for histogram filling
         Type::HistContent content(weight, dist);
@@ -261,7 +269,7 @@ namespace PHEnergyCorrelator {
         }
         return;
 
-      }  // end 'CalcEEC(Type::Jet&, std::pair<Type::Cst, Type::Cst>&)'
+      }  // end 'CalcEEC(Type::Jet&, std::pair<Type::Cst, Type::Cst>&, double)'
 
       // ----------------------------------------------------------------------
       //! End calculations

--- a/include/PHCorrelatorHistogram.h
+++ b/include/PHCorrelatorHistogram.h
@@ -47,6 +47,19 @@ namespace PHEnergyCorrelator {
       Binning     m_bins_y;
       Binning     m_bins_z;
 
+      // ----------------------------------------------------------------------
+      //! Make histogram title
+      // ----------------------------------------------------------------------
+      std::string MakeTitle() const {
+
+        std::string title = m_title;
+        title.append( ";" + m_title_x );
+        title.append( ";" + m_title_y );
+        title.append( ";" + m_title_z );
+        return title;
+
+      }  // end 'MakeTitle()'
+
     public:
 
       // ----------------------------------------------------------------------
@@ -98,13 +111,15 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       TH1D* MakeTH1() const {
 
+        // make hist + axis titles
+        const std::string title = MakeTitle();
+
         TH1D* hist = new TH1D(
           m_name.data(),
-          m_title.data(),
+          title.data(),
           m_bins_x.GetNum(),
           m_bins_x.GetBins().data()
         );
-        hist -> GetXaxis() -> SetTitle(m_title_x.data());
         return hist;
 
       }  // end 'MakeTH1()'
@@ -114,16 +129,17 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       TH2D* MakeTH2() const {
 
+        // make hist + axis titles
+        const std::string title = MakeTitle();
+
         TH2D* hist = new TH2D(
           m_name.data(),
-          m_title.data(),
+          title.data(),
           m_bins_x.GetNum(),
           m_bins_x.GetBins().data(),
           m_bins_y.GetNum(),
           m_bins_y.GetBins().data()
         );
-        hist -> GetXaxis() -> SetTitle(m_title_x.data());
-        hist -> GetYaxis() -> SetTitle(m_title_y.data());
         return hist;
 
       }  // end 'MakeTH2()'
@@ -133,9 +149,12 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       TH3D* MakeTH3() const {
 
+        // make hist + axis titles
+        const std::string title = MakeTitle();
+
         TH3D* hist = new TH3D(
           m_name.data(),
-          m_title.data(),
+          title.data(),
           m_bins_x.GetNum(),
           m_bins_x.GetBins().data(),
           m_bins_y.GetNum(),
@@ -143,9 +162,6 @@ namespace PHEnergyCorrelator {
           m_bins_z.GetNum(),
           m_bins_z.GetBins().data()
         );
-        hist -> GetXaxis() -> SetTitle(m_title_x.data());
-        hist -> GetYaxis() -> SetTitle(m_title_y.data());
-        hist -> GetZaxis() -> SetTitle(m_title_z.data());
         return hist;
 
       }  // end 'MakeTH3()'
@@ -179,4 +195,3 @@ namespace PHEnergyCorrelator {
 #endif
 
 // end ========================================================================
-

--- a/include/PHCorrelatorHistogram.h
+++ b/include/PHCorrelatorHistogram.h
@@ -166,6 +166,22 @@ namespace PHEnergyCorrelator {
 
       }  // end 'MakeTH3()'
 
+      // -----------------------------------------------------------------------
+      //! Helper method to set 1d histogram errors to be variances
+      // -----------------------------------------------------------------------
+      static void SetHist1DErrToVar(TH1D* hist) {
+
+        for (int ibin = 1; ibin <= hist -> GetNbinsX(); ++ibin) {
+          const double var = Tools::GetVariance(
+            hist -> GetBinError(ibin),
+            hist -> GetBinContent(ibin)
+          );
+          hist -> SetBinError(ibin, var);
+        }  // end bin loop
+        return;
+
+      }  // end 'SetHist1DErrTOVar(TH1D*)'
+
       // ----------------------------------------------------------------------
       //! default ctor/dtor
       // ----------------------------------------------------------------------

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -29,8 +29,6 @@
 #include "PHCorrelatorTools.h"
 #include "PHCorrelatorTypes.h"
 
-// TEST
-#include <iostream>
 
 
 namespace PHEnergyCorrelator {
@@ -163,6 +161,27 @@ namespace PHEnergyCorrelator {
 
       }  // end 'GenerateEECHists()'
 
+      // ----------------------------------------------------------------------
+      //! Set variances of relevant 2-point histograms
+      // ----------------------------------------------------------------------
+      void SetEECVariances() {
+
+        // names of EEC hists to set variances of
+        std::vector<std::string> to_set;
+        to_set.push_back( "hEECWidth_" );
+        to_set.push_back( "hLogEECWidth_" );
+
+        for (std::size_t index = 0; index < m_index_tags.size(); ++index) {
+          for (std::size_t iset = 0; iset < to_set.size(); ++iset) {
+            Histogram::SetHist1DErrToVar(
+              m_hist_1d[ to_set[iset] + m_index_tags[index] ]
+            );
+          }
+        }
+        return;
+
+      }  // end 'SetEECVariances()'
+
     public:
 
       // ----------------------------------------------------------------------
@@ -259,7 +278,9 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       void SaveHists(TFile* file) {
 
-        /* TODO set error bar on 'width' histograms before saving */
+        // set variances on relevant histograms
+        //   - TODO add others when ready
+        if (m_do_eec_hist) SetEECVariances();
 
         // throw error if cd failed
         const bool good_cd = file -> cd();

--- a/include/PHCorrelatorTools.h
+++ b/include/PHCorrelatorTools.h
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <vector>
 // root libraries
+#include <TH1.h>
 #include <TLorentzVector.h>
 #include <TString.h>
 #include <TVector3.h>
@@ -66,6 +67,19 @@ namespace PHEnergyCorrelator {
       return dist;
 
     }  // end 'GetCstDist(std::pair<Type::Cst, Type::Cst>&)'
+
+
+
+    // ------------------------------------------------------------------------
+    //! Get variance from a standard error + counts
+    // ------------------------------------------------------------------------
+    double GetVariance(const double err, const double counts) {
+
+      const double sqvar = err * sqrt(counts);
+      const double var   = sqvar * sqvar;
+      return var;
+
+    }  // end 'GetVariance(double, double)'
 
 
 

--- a/test/jetAnaSim.C
+++ b/test/jetAnaSim.C
@@ -1901,8 +1901,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
             );
 
             // run 2-point calculation for pair
-            //   - TODO add piping for event weights
-            calculator.CalcEEC( jet, std::make_pair(cstA, cstB) );
+            calculator.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
 
           }  // end 2nd cst loop
         }  // end 1st cst loop


### PR DESCRIPTION
This PR adds the calculations to the simulation analysis macro (`test/jetAnaSim.C`) and makes a few small improvements, incl.

- Axis titles are now consistently applied when creating histograms;
- The "Width" histograms now have the variances set as the bin errors;
- ROOT and build files are now ignored;
- And a spurious "TEST" line was removed.