### PR TITLE
Add EEC calc to reconstructed jets in sim macro

### DIFF
--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -14,6 +14,7 @@
 // c++ utilities
 #include <algorithm>
 #include <utility>
+#include <string>
 #include <vector>
 // root libraries
 #include <TLorentzVector.h>
@@ -40,12 +41,13 @@ namespace PHEnergyCorrelator {
       Type::Weight m_weight_type;
 
       // data members (hist options)
-      bool m_do_eec_hist;
-      bool m_do_e3c_hist;
-      bool m_do_lec_hist;
-      bool m_do_pt_bins;
-      bool m_do_cf_bins;
-      bool m_do_sp_bins;
+      bool        m_do_eec_hist;
+      bool        m_do_e3c_hist;
+      bool        m_do_lec_hist;
+      bool        m_do_pt_bins;
+      bool        m_do_cf_bins;
+      bool        m_do_sp_bins;
+      std::string m_hist_tag;
 
       // data members (bins)
       std::vector< std::pair<float, float> > m_ptjet_bins;
@@ -151,6 +153,7 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Setters
       // ----------------------------------------------------------------------
+      void SetHistTag(const std::string& tag)       {m_hist_tag     = tag;}
       void SetWeightPower(const double power)       {m_weight_power = power;}
       void SetWeightType(const Type::Weight weight) {m_weight_type  = weight;}
 
@@ -222,6 +225,7 @@ namespace PHEnergyCorrelator {
         m_manager.DoEECHists(m_do_eec_hist);
         m_manager.DoE3CHists(m_do_e3c_hist);
         m_manager.DoLECHists(m_do_lec_hist);
+        m_manager.SetHistTag(m_hist_tag);
         m_manager.GenerateHists();
         return;
 
@@ -230,7 +234,7 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Do EEC calculation
       // ----------------------------------------------------------------------
-      /*! Note that the optional third argument, `evtweight` is there
+      /*! Note that the optional third argument, `evtweight`, is there
        *  to allow for weighting by ckin, spin, etc. By default, it's
        *  set to 1.
        */ 

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -68,7 +68,9 @@ namespace PHEnergyCorrelator {
       std::size_t m_nbins_cf;
       std::size_t m_nbins_sp;
 
-      // data members (index tags)
+      // data members (tags)
+      std::string              m_hist_tag;
+      std::string              m_hist_pref;
       std::vector<std::string> m_index_tags;
 
       // data members (histograms)
@@ -82,7 +84,7 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Make a tag from a histogram index 
       // ----------------------------------------------------------------------
-      std::string MakeIndexTag(const Type::HistIndex& index) {
+      std::string MakeIndexTag(const Type::HistIndex& index) const {
 
         // by default, return empty string
         std::string tag = "";
@@ -96,9 +98,27 @@ namespace PHEnergyCorrelator {
       }  // end 'MakeIndexTag(Type::HistIndex&)'
 
       // ----------------------------------------------------------------------
-      //! Create tags for bins
+      //! Make a histogram suffix from a tag
       // ----------------------------------------------------------------------
-      void CreateIndexTags() {
+      std::string MakeHistSuffix(const std::string& tag) const {
+
+        return "_" + tag;
+
+      }  // end 'MakeHistSuffix(std::string&)'
+
+      // ----------------------------------------------------------------------
+      //! Make a histogram name from a base and a tag
+      // ----------------------------------------------------------------------
+      std::string MakeHistName(const std::string& base, const std::string& tag) const {
+
+        return m_hist_pref + base + MakeHistSuffix(tag);
+
+      }  // end 'MakeHistName(std::string&, std::string&)'
+
+      // ----------------------------------------------------------------------
+      //! Generate tags for bins
+      // ----------------------------------------------------------------------
+      void GenerateIndexTags() {
 
         // build list of indices
         std::vector<Type::HistIndex> indices;
@@ -117,7 +137,17 @@ namespace PHEnergyCorrelator {
         }
         return;
 
-      }  // end 'CreateIndexTags()'
+      }  // end 'GenerateIndexTags()'
+
+      // ----------------------------------------------------------------------
+      //! Generate prefix for histograms
+      // ----------------------------------------------------------------------
+      void GenerateHistPrefix() {
+
+        m_hist_pref = "h" + m_hist_tag;
+        return;
+
+      }  // end 'GenerateHistPrefix()'
 
       // ----------------------------------------------------------------------
       //! Generate 2-point histograms
@@ -148,8 +178,8 @@ namespace PHEnergyCorrelator {
 
             // grab definition, adjust name
             Histogram hist = def_1d[ihist];
-            hist.PrependToName("h");
-            hist.AppendToName("_" + m_index_tags[index]);
+            hist.PrependToName( m_hist_pref );
+            hist.AppendToName( MakeHistSuffix(m_index_tags[index]) );
 
             // create histogram, set errors
             m_hist_1d[hist.GetName()] = hist.MakeTH1();
@@ -168,13 +198,13 @@ namespace PHEnergyCorrelator {
 
         // names of EEC hists to set variances of
         std::vector<std::string> to_set;
-        to_set.push_back( "hEECWidth_" );
-        to_set.push_back( "hLogEECWidth_" );
+        to_set.push_back( "EECWidth" );
+        to_set.push_back( "LogEECWidth" );
 
         for (std::size_t index = 0; index < m_index_tags.size(); ++index) {
           for (std::size_t iset = 0; iset < to_set.size(); ++iset) {
             Histogram::SetHist1DErrToVar(
-              m_hist_1d[ to_set[iset] + m_index_tags[index] ]
+              m_hist_1d[ MakeHistName(to_set[iset], m_index_tags[index]) ]
             );
           }
         }
@@ -187,14 +217,20 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Getters
       // ----------------------------------------------------------------------
+      std::string GetHistTag()    const {return m_hist_tag;}
       std::size_t GetNPtJetBins() const {return m_nbins_pt;}
       std::size_t GetNCFJetBins() const {return m_nbins_cf;}
       std::size_t GetNSpinBins()  const {return m_nbins_sp;}
-      std::size_t GetNTags()      const {return m_index_tags.size();}
+      std::size_t GetNIndexTags() const {return m_index_tags.size();}
       std::size_t GetNHist1D()    const {return m_hist_1d.size();}
       std::size_t GetNHist2D()    const {return m_hist_2d.size();}
       std::size_t GetNHist3D()    const {return m_hist_3d.size();}
       std::size_t GetNHists()     const {return GetNHist1D() + GetNHist2D() + GetNHist3D();}
+
+      // ----------------------------------------------------------------------
+      //! Set hist tag
+      // ----------------------------------------------------------------------
+      void SetHistTag(const std::string& tag) {m_hist_tag = tag;}
 
       // ----------------------------------------------------------------------
       //! Set histogram options
@@ -246,8 +282,9 @@ namespace PHEnergyCorrelator {
         m_nbins_cf = m_do_cf_bins ? m_nbins_cf : (std::size_t) 1;
         m_nbins_sp = m_do_sp_bins ? m_nbins_sp : (std::size_t) 1;
 
-        // then create tags for each bin
-        CreateIndexTags();
+        // then create tags for each bin and histogrma prefixes
+        GenerateIndexTags();
+        GenerateHistPrefix();
 
         // finally generate appropriate histograms
         //   - TODO add others when ready
@@ -265,10 +302,10 @@ namespace PHEnergyCorrelator {
         const std::string tag = MakeIndexTag(index);
 
         // fill histograms
-        m_hist_1d["hEECStat_" + tag]     -> Fill( content.rl, content.weight );
-        m_hist_1d["hEECWidth_" + tag]    -> Fill( content.rl, content.weight );
-        m_hist_1d["hLogEECStat_" + tag]  -> Fill( Tools::Log(content.rl), content.weight );
-        m_hist_1d["hLogEECWidth_" + tag] -> Fill( Tools::Log(content.rl), content.weight );
+        m_hist_1d[ MakeHistName("EECStat", tag)     ] -> Fill( content.rl, content.weight );
+        m_hist_1d[ MakeHistName("EECWidth", tag)    ] -> Fill( content.rl, content.weight );
+        m_hist_1d[ MakeHistName("LogEECStat", tag)  ] -> Fill( Tools::Log(content.rl), content.weight );
+        m_hist_1d[ MakeHistName("LogEECWidth", tag) ] -> Fill( Tools::Log(content.rl), content.weight );
         return;
 
       }  // end 'FillEECHists(Type::HistIndex&, Type::HistContent&)'
@@ -366,6 +403,8 @@ namespace PHEnergyCorrelator {
         m_nbins_pt    = 1;
         m_nbins_cf    = 1;
         m_nbins_sp    = 1;
+        m_hist_tag    = "";
+        m_hist_pref   = "";
 
       }  // end default ctor
 
@@ -388,6 +427,8 @@ namespace PHEnergyCorrelator {
         m_nbins_pt    = 1;
         m_nbins_cf    = 1;
         m_nbins_sp    = 1;
+        m_hist_tag    = "";
+        m_hist_pref   = "";
 
       }  // end 'Manager(bool, bool, bool)'
 

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -82,7 +82,7 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Make a tag from a histogram index 
       // ----------------------------------------------------------------------
-      std::string MakeTag(const Type::HistIndex& index) {
+      std::string MakeIndexTag(const Type::HistIndex& index) {
 
         // by default, return empty string
         std::string tag = "";
@@ -93,12 +93,12 @@ namespace PHEnergyCorrelator {
         if (m_do_sp_bins) tag += Const::SpinTag() + Tools::StringifyIndex(index.spin);
         return tag;
 
-      }  // end 'GetTag(Type::HistIndex&)'
+      }  // end 'MakeIndexTag(Type::HistIndex&)'
 
       // ----------------------------------------------------------------------
       //! Create tags for bins
       // ----------------------------------------------------------------------
-      void CreateBinTags() {
+      void CreateIndexTags() {
 
         // build list of indices
         std::vector<Type::HistIndex> indices;
@@ -113,11 +113,11 @@ namespace PHEnergyCorrelator {
         // create tags and return
         m_index_tags.clear();
         for (std::size_t index = 0; index < indices.size(); ++index) {
-          m_index_tags.push_back( MakeTag(indices[index]) );
+          m_index_tags.push_back( MakeIndexTag(indices[index]) );
         }
         return;
 
-      }  // end 'CreateBinTags()'
+      }  // end 'CreateIndexTags()'
 
       // ----------------------------------------------------------------------
       //! Generate 2-point histograms
@@ -247,7 +247,7 @@ namespace PHEnergyCorrelator {
         m_nbins_sp = m_do_sp_bins ? m_nbins_sp : (std::size_t) 1;
 
         // then create tags for each bin
-        CreateBinTags();
+        CreateIndexTags();
 
         // finally generate appropriate histograms
         //   - TODO add others when ready
@@ -262,7 +262,7 @@ namespace PHEnergyCorrelator {
       void FillEECHists(const Type::HistIndex& index, const Type::HistContent& content) {
 
         // grab hist tag from index
-        const std::string tag = MakeTag(index);
+        const std::string tag = MakeIndexTag(index);
 
         // fill histograms
         m_hist_1d["hEECStat_" + tag]     -> Fill( content.rl, content.weight );
@@ -346,11 +346,11 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Get a histogram tag from a histogram index
       // ----------------------------------------------------------------------
-      std::string GetTag(const Type::HistIndex& index) {
+      std::string GetIndexTag(const Type::HistIndex& index) {
 
-        return MakeTag(index);
+        return MakeIndexTag(index);
 
-      }  // end 'GetTag(Type::HistIndex&)'
+      }  // end 'GetIndexTag(Type::HistIndex&)'
 
       // ----------------------------------------------------------------------
       //! default ctor

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -59,20 +59,20 @@ void PHEnergyCorrelatorTest() {
   cfjetbins.push_back( std::make_pair(0.5, 1.) );
 
   // instantiate calculator
-  PHEC::Calculator calc(PHEC::Type::Pt);
-  calc.SetPtJetBins(ptjetbins);
-  calc.SetCFJetBins(cfjetbins);
-  calc.SetHistTag("Test");
+  PHEC::Calculator calc_a(PHEC::Type::Pt);
+  calc_a.SetPtJetBins(ptjetbins);
+  calc_a.SetCFJetBins(cfjetbins);
+  calc_a.SetHistTag("FirstTest");
 
   // check no. of bins
-  std::cout << "      --- N pt bins = " << calc.GetManager().GetNPtJetBins() << "\n"
-            << "      --- N CF bins = " << calc.GetManager().GetNCFJetBins()
+  std::cout << "      --- N pt bins = " << calc_a.GetManager().GetNPtJetBins() << "\n"
+            << "      --- N CF bins = " << calc_a.GetManager().GetNCFJetBins()
             << std::endl;
 
   // create histograms
-  calc.Init(true);
-  std::cout << "      --- N tags    = " << calc.GetManager().GetNIndexTags() << "\n"
-            << "      --- N hists   = " << calc.GetManager().GetNHists()
+  calc_a.Init(true);
+  std::cout << "      --- N tags    = " << calc_a.GetManager().GetNIndexTags() << "\n"
+            << "      --- N hists   = " << calc_a.GetManager().GetNHists()
             << std::endl;
 
   // --------------------------------------------------------------------------
@@ -109,7 +109,36 @@ void PHEnergyCorrelatorTest() {
         if (icst_a == icst_b) continue;
 
         // do calculation
-        calc.CalcEEC(
+        calc_a.CalcEEC(
+          jets[ijet],
+          std::make_pair(csts[ijet][icst_a], csts[ijet][icst_b])
+        );
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Test adding 2nd calculator
+  // --------------------------------------------------------------------------
+  std::cout << "    Case [3]: test adding a 2nd calculator" << std::endl;
+
+  // instantiate calculator
+  PHEC::Calculator calc_b(PHEC::Type::Pt);
+  calc_b.SetPtJetBins(ptjetbins);
+  calc_b.SetCFJetBins(cfjetbins);
+  calc_b.SetHistTag("SecondTest");
+  calc_b.Init(true);
+
+  // run calculations
+  for (std::size_t ijet = 0; ijet < jets.size(); ++ijet) {
+    for (std::size_t icst_a = 0; icst_a < csts[ijet].size(); ++icst_a) {
+      for (std::size_t icst_b = 0; icst_b < csts[ijet].size(); ++icst_b) {
+
+        // skip diagonal
+        if (icst_a == icst_b) continue;
+
+        // do calculation
+        calc_b.CalcEEC(
           jets[ijet],
           std::make_pair(csts[ijet][icst_a], csts[ijet][icst_b])
         );
@@ -120,13 +149,14 @@ void PHEnergyCorrelatorTest() {
   // --------------------------------------------------------------------------
   // Save histograms
   // --------------------------------------------------------------------------
-  std::cout << "    Case [3]: test saving histograms" << std::endl;
+  std::cout << "    Case [4]: test saving histograms" << std::endl;
 
   // create output file
   TFile* output = new TFile("test.root", "recreate");
 
   // save histograms to output
-  calc.End(output);
+  calc_a.End(output);
+  calc_b.End(output);
 
   // --------------------------------------------------------------------------
   // Tests complete

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -62,6 +62,7 @@ void PHEnergyCorrelatorTest() {
   PHEC::Calculator calc(PHEC::Type::Pt);
   calc.SetPtJetBins(ptjetbins);
   calc.SetCFJetBins(cfjetbins);
+  calc.SetHistTag("Test");
 
   // check no. of bins
   std::cout << "      --- N pt bins = " << calc.GetManager().GetNPtJetBins() << "\n"
@@ -70,7 +71,7 @@ void PHEnergyCorrelatorTest() {
 
   // create histograms
   calc.Init(true);
-  std::cout << "      --- N tags    = " << calc.GetManager().GetNTags() << "\n"
+  std::cout << "      --- N tags    = " << calc.GetManager().GetNIndexTags() << "\n"
             << "      --- N hists   = " << calc.GetManager().GetNHists()
             << std::endl;
 

--- a/test/jetAnaSim.C
+++ b/test/jetAnaSim.C
@@ -32,7 +32,7 @@
 using namespace LHAPDF; 
 
 // ----------------------------------------------------------------------------
-// EEC Calculations
+// EEC calculations
 // ----------------------------------------------------------------------------
 /*  Make sure the EEC path is pointed to wherever
  *  the repo is located. We'll need <utility> for
@@ -796,7 +796,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
 	       const int useML = 0, int AcceptFlag = -1, int halfstats = 0, int p_or_h_flag = 1, std::string inSuffix=""){
 
   // --------------------------------------------------------------------------
-  // EEC Calculations
+  // EEC calculations
   // --------------------------------------------------------------------------
 
 // define flags to turn off certain calculations
@@ -2643,7 +2643,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
   hFFdROppPat_odd->Add(hFFdRSpinPat[1][2]);
 
   // --------------------------------------------------------------------------
-  // EEC Calculations
+  // EEC calculations
   // --------------------------------------------------------------------------
 
   if (doTrue && doAllTrueEEC) allTrueCalc.End( fOut );


### PR DESCRIPTION
This PR applies the EEC calculation to the reconstructed jets in `jetAnaSim.C`. To do this, a few changes had to be implemented, and some other QoL features were added along the way. Changes:

- Index tag makers, getters, and setters were renamed to allow for a global histogram tag to be introduced;
- A global histogram tag was introduced, which allows for multiple calculations to be run in a single macro;
- Additional calculations were added to `jetAna.C` and `jetAnaSim.C` -- including calculations on the reco jets in the latter -- to look at both EECs in _all_ jets vs. EECs in just the _max pt_ jet;
- Typos were fixed in the truth jet calculations, which should resolve the `std::out_of_range` error.