### PR TITLE
Prepare for spin sorting

### DIFF
--- a/include/PHCorrelatorBins.h
+++ b/include/PHCorrelatorBins.h
@@ -91,14 +91,12 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       Bins() {
 
-        /* TODO
-         *  - Add cos(angle)
-         *  - Add angle
-         *  - Add xi
-         */
-        m_bins["energy"]  = Binning(202, -1., 100.);
-        m_bins["side"]    = Binning(75, 1e-5, 1., Type::Log);
-        m_bins["logside"] = Binning(75, -5., 0.);
+        m_bins["energy"]   = Binning(202, -1., 100.);
+        m_bins["side"]     = Binning(75, 1e-5, 1., Type::Log);
+        m_bins["logside"]  = Binning(75, -5., 0.);
+        m_bins["angle"]    = Binning(180, -3.15, 3.15);
+        m_bins["cosangle"] = Binning(20, -1., 1.);
+        m_bins["xi"]       = Binning(100, 0., 1.);
 
       }  // end 'ctor()'
 

--- a/include/PHCorrelatorBins.h
+++ b/include/PHCorrelatorBins.h
@@ -97,6 +97,7 @@ namespace PHEnergyCorrelator {
         m_bins["angle"]    = Binning(180, -3.15, 3.15);
         m_bins["cosangle"] = Binning(20, -1., 1.);
         m_bins["xi"]       = Binning(100, 0., 1.);
+        m_bins["pattern"]  = Binning(5, -0.5, 4.5);
 
       }  // end 'ctor()'
 

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -241,7 +241,8 @@ namespace PHEnergyCorrelator {
       void CalcEEC(
         const Type::Jet& jet,
         const std::pair<Type::Cst, Type::Cst>& csts,
-        const double evtweight = 1.0
+        const double evt_weight = 1.0,
+        const TVector3 spin_vec = TVector3(0., 0, 0) 
       ) {
 
         // get jet 4-momenta
@@ -253,18 +254,26 @@ namespace PHEnergyCorrelator {
           Tools::GetCstLorentz(jet_vec.Vect(), csts.second)
         );
 
+        // get vector distance b/n average of cst.s and spin direction
+        TLorentzVector cst_avg = Tools::GetWeightedAvgLorentz(
+          cst_vecs.first,
+          cst_vecs.second
+        );
+
         // now get weights
         std::pair<double, double> cst_weights = std::make_pair(
           GetCstWeight(cst_vecs.first, jet_vec),
           GetCstWeight(cst_vecs.second, jet_vec)
         );
 
-        // calculate RL (dist b/n cst.s for EEC) 
+        // calculate RL (dist b/n cst.s for EEC), EEC, and
+        // angle b/n the cst average and spin
         const double dist   = Tools::GetCstDist(csts);
-        const double weight = cst_weights.first * cst_weights.second * evtweight;
+        const double weight = cst_weights.first * cst_weights.second * evt_weight;
+        const double phi    = Tools::GetSiversAngle(cst_avg.Vect(), spin_vec);
 
         // bundle results for histogram filling
-        Type::HistContent content(weight, dist);
+        Type::HistContent content(weight, dist, phi);
 
         // fill histograms and exit
         Type::HistIndex index = GetHistIndex(jet);
@@ -321,7 +330,7 @@ namespace PHEnergyCorrelator {
         m_do_cf_bins   = false;
         m_do_sp_bins   = false;
 
-      }  // end ctor(Type::Weight, double)'
+      }  // end ctor(Type::Weight, double)
 
   };  // end PHEnergyCorrelator::Calculator
 

--- a/include/PHCorrelatorHistogram.h
+++ b/include/PHCorrelatorHistogram.h
@@ -11,6 +11,7 @@
 #define PHCORRELATORHISTOGRAM_H
 
 // c++ utilities
+#include <cassert>
 #include <string>
 #include <vector>
 // root libraries
@@ -81,6 +82,52 @@ namespace PHEnergyCorrelator {
       void SetHistName(const std::string& name)     {m_name = name;}
       void PrependToName(const std::string& prefix) {m_name = prefix + m_name;}
       void AppendToName(const std::string& suffix)  {m_name = m_name + suffix;}
+
+      // ----------------------------------------------------------------------
+      //! Set specific axis title
+      // ----------------------------------------------------------------------
+      void SetAxisTitle(const std::string& title, const std::size_t axis) {
+
+        switch (axis) {
+          case 0:
+            m_title_x = title;
+            break;
+          case 1:
+            m_title_y = title;
+            break;
+          case 2:
+            m_title_z = title;
+            break;
+          default:
+            assert(axis < 3);
+            break;
+        }
+        return;
+
+      }  // end 'SetAxisTitle(std::string&, std::size_t)'
+
+      // ----------------------------------------------------------------------
+      //! Set specific binning
+      // ----------------------------------------------------------------------
+      void SetAxisBins(const Binning& bins, const std::size_t axis) {
+
+        switch (axis) {
+          case 0:
+            m_bins_x = bins;
+            break;
+          case 1:
+            m_bins_y = bins;
+            break;
+          case 2:
+            m_bins_z = bins;
+            break;
+          default:
+            assert(axis < 3);
+            break;
+        }
+        return;
+
+      }  // end 'SetAxisBins(Binning&, std::size_t)'
 
       // ----------------------------------------------------------------------
       //! Set axis titles via list
@@ -189,7 +236,24 @@ namespace PHEnergyCorrelator {
        ~Histogram() {};
 
       // ----------------------------------------------------------------------
-      //! ctor accepting arguments
+      //! ctor accepting arguments (1 binning, 1 axis title)
+      // ----------------------------------------------------------------------
+      Histogram(
+        const std::string& hist_name,
+        const std::string& hist_title,
+        const std::string& axis_title,
+        const Binning& axis_bins
+      ) {
+
+        SetHistName(hist_name);
+        SetHistTitle(hist_title);
+        SetAxisTitle(axis_title, 0);
+        SetAxisBins(axis_bins, 0);
+
+      }  // end ctor(std::string&, std::string&, std::string&, Binning&)'
+
+      // ----------------------------------------------------------------------
+      //! ctor accepting arguments (vector of axis titles/bins)
       // ----------------------------------------------------------------------
       Histogram(
         const std::string& hist_name,
@@ -203,7 +267,7 @@ namespace PHEnergyCorrelator {
         SetAxisTitles(axis_titles);
         SetAxisBins(axis_bins);
 
-      }  // end 'ctor(std::string&, std::string&, std::vector<std::string>&, std::vector<Binning>&)'
+      }  // end ctor(std::string&, std::string&, std::vector<std::string>&, std::vector<Binning>&)
 
   };  // end Histogram
 }  // end PHEnergyCorrelator namespace

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -83,9 +83,9 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Translate spin index into a tag
       // ----------------------------------------------------------------------
-      std::string GetSpinTag(const std::size_t isp) {
+      std::string GetSpinTag(const std::size_t isp) const {
 
-        std::String tag = "";
+        std::string tag = "";
         switch (isp) {
           case 0:
             tag = "BlueUp";
@@ -226,6 +226,7 @@ namespace PHEnergyCorrelator {
         def_1d.push_back(Histogram("EECWidth", "", "R_{L}", m_bins.Get("side")));
         def_1d.push_back(Histogram("LogEECStat", "", "log R_{L}", m_bins.Get("logside")));
         def_1d.push_back(Histogram("LogEECWidth", "", "log R_{L}", m_bins.Get("logside")));
+        def_1d.push_back(Histogram("SpinPattern", "", "pattern", m_bins.Get("pattern")));
         def_1d.push_back(Histogram("SpinPhiStat", "", "#varphi", m_bins.Get("angle")));
 
         // vectors of binnings for 2d histograms
@@ -333,9 +334,9 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Bin on spin
       // ----------------------------------------------------------------------
-      void DoSpinBins() {
+      void DoSpinBins(const bool spin) {
 
-        m_do_sp_bins = true;
+        m_do_sp_bins = spin;
         return;
 
       }  // end 'DoSpinBins()'
@@ -374,6 +375,7 @@ namespace PHEnergyCorrelator {
         m_hist_1d[MakeHistName("EECWidth", tag)] -> Fill(content.rl, content.weight);
         m_hist_1d[MakeHistName("LogEECStat", tag)] -> Fill(Tools::Log(content.rl), content.weight);
         m_hist_1d[MakeHistName("LogEECWidth", tag)] -> Fill(Tools::Log(content.rl), content.weight);
+        m_hist_1d[MakeHistName("SpinPattern", tag)] -> Fill(content.pattern);
         m_hist_1d[MakeHistName("SpinPhiStat", tag)] -> Fill(content.phi);
 
         // fill 2d histograms

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -81,6 +81,36 @@ namespace PHEnergyCorrelator {
       Bins m_bins;
 
       // ----------------------------------------------------------------------
+      //! Translate spin index into a tag
+      // ----------------------------------------------------------------------
+      std::string GetSpinTag(const std::size_t isp) {
+
+        std::String tag = "";
+        switch (isp) {
+          case 0:
+            tag = "BlueUp";
+            break;
+          case 1:
+            tag = "BlueDown";
+            break;
+          case 2:
+            tag = "YellUp";
+            break;
+          case 3:
+            tag = "YellDown";
+            break;
+          case 4:
+            tag = "Integrated";
+            break;
+          default:
+            tag = "";
+            break;
+        }
+        return tag;
+
+      }  // end 'GetSpinTag(std::size_t)'
+
+      // ----------------------------------------------------------------------
       //! Make a tag from a histogram index 
       // ----------------------------------------------------------------------
       std::string MakeIndexTag(const Type::HistIndex& index) const {
@@ -91,7 +121,7 @@ namespace PHEnergyCorrelator {
         // add appropriate indices
         if (m_do_pt_bins) tag += Const::PtTag() + Tools::StringifyIndex(index.pt);
         if (m_do_cf_bins) tag += Const::CFTag() + Tools::StringifyIndex(index.cf);
-        if (m_do_sp_bins) tag += Const::SpinTag() + Tools::StringifyIndex(index.spin);
+        if (m_do_sp_bins) tag += Const::SpinTag() + GetSpinTag(index.spin);
         return tag;
 
       }  // end 'MakeIndexTag(Type::HistIndex&)'
@@ -303,13 +333,12 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Bin on spin
       // ----------------------------------------------------------------------
-      void DoSpinBins(const std::size_t nbins) {
+      void DoSpinBins() {
 
-        m_nbins_sp   = nbins;
         m_do_sp_bins = true;
         return;
 
-      }  // end 'DoSpinBins(std::size_t)'
+      }  // end 'DoSpinBins()'
 
       // ----------------------------------------------------------------------
       //! Generate histograms
@@ -450,7 +479,7 @@ namespace PHEnergyCorrelator {
         m_do_sp_bins  = false;
         m_nbins_pt    = 1;
         m_nbins_cf    = 1;
-        m_nbins_sp    = 1;
+        m_nbins_sp    = 5;
         m_hist_tag    = "";
         m_hist_pref   = "";
 
@@ -474,7 +503,7 @@ namespace PHEnergyCorrelator {
         m_do_sp_bins  = false;
         m_nbins_pt    = 1;
         m_nbins_cf    = 1;
-        m_nbins_sp    = 1;
+        m_nbins_sp    = 5;
         m_hist_tag    = "";
         m_hist_pref   = "";
 

--- a/include/PHCorrelatorTools.h
+++ b/include/PHCorrelatorTools.h
@@ -71,6 +71,16 @@ namespace PHEnergyCorrelator {
 
 
     // ------------------------------------------------------------------------
+    //! Get sivers angle
+    // ------------------------------------------------------------------------
+    double GetSiversAngle(const TVector3& had_vec, const TVector3& spin_vec) {
+
+      return remainder(had_vec.Phi() - spin_vec.Phi(), TMath::TwoPi());
+
+    }  // end 'GetSiversAngle(TVector3& x 2)'
+
+
+    // ------------------------------------------------------------------------
     //! Get variance from a standard error + counts
     // ------------------------------------------------------------------------
     double GetVariance(const double err, const double counts) {
@@ -186,6 +196,21 @@ namespace PHEnergyCorrelator {
       return TLorentzVector(px, py, pz, ptot);
 
     }  // end 'GetCstLorentz(TVector3, Type::Cst&)'
+
+
+    // ------------------------------------------------------------------------
+    //! Get weighted average of 2 4-vectors
+    // ------------------------------------------------------------------------
+    TLorentzVector GetWeightedAvgLorentz(
+      const TLorentzVector& va,
+      const TLorentzVector& vb
+    ) {
+
+      const float wa = va.E() / (va.E() + vb.E());
+      const float wb = vb.E() / (va.E() + vb.E());
+      return (wa * va) + (wb * vb);
+
+    }  // end 'GetWeightedAvgLorentz(TLorentzVector& x 2)'
 
   }  // end Tools namespace
 }  // end PHEnergyCorrelator namespace

--- a/include/PHCorrelatorTools.h
+++ b/include/PHCorrelatorTools.h
@@ -71,16 +71,6 @@ namespace PHEnergyCorrelator {
 
 
     // ------------------------------------------------------------------------
-    //! Get sivers angle
-    // ------------------------------------------------------------------------
-    double GetSiversAngle(const TVector3& had_vec, const TVector3& spin_vec) {
-
-      return remainder(had_vec.Phi() - spin_vec.Phi(), TMath::TwoPi());
-
-    }  // end 'GetSiversAngle(TVector3& x 2)'
-
-
-    // ------------------------------------------------------------------------
     //! Get variance from a standard error + counts
     // ------------------------------------------------------------------------
     double GetVariance(const double err, const double counts) {

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -42,7 +42,9 @@ namespace PHEnergyCorrelator {
       double pt;
       double eta;
       double phi;
-      double spin;
+      double phiblu;
+      double phiyell;
+      int    pattern;
 
       //! default ctor/dtor
       Jet()  {};
@@ -54,13 +56,17 @@ namespace PHEnergyCorrelator {
         const double parg,
         const double harg,
         const double farg,
-        const double sarg
+        const double fbarg,
+        const double fyarg,
+        const int    parg
       ) {
-        cf   = carg;
-        pt   = parg;
-        eta  = harg;
-        phi  = farg;
-        spin = sarg;
+        cf      = carg;
+        pt      = parg;
+        eta     = harg;
+        phi     = farg;
+        phiblu  = fbarg;
+        phiyel  = fyarg;
+        pattern = parg; 
       };
 
     };  // end Jet

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -43,7 +43,7 @@ namespace PHEnergyCorrelator {
       double eta;
       double phi;
       double phiblu;
-      double phiyell;
+      double phiyel;
       int    pattern;
 
       //! default ctor/dtor
@@ -56,9 +56,9 @@ namespace PHEnergyCorrelator {
         const double parg,
         const double harg,
         const double farg,
-        const double fbarg,
-        const double fyarg,
-        const int    parg
+        const double fbarg = 0.,
+        const double fyarg = 0.,
+        const int    aarg  = 0
       ) {
         cf      = carg;
         pt      = parg;
@@ -66,7 +66,7 @@ namespace PHEnergyCorrelator {
         phi     = farg;
         phiblu  = fbarg;
         phiyel  = fyarg;
-        pattern = parg; 
+        pattern = aarg; 
       };
 
     };  // end Jet
@@ -150,6 +150,7 @@ namespace PHEnergyCorrelator {
       double xi;
       double theta;
       double phi;
+      int    pattern;
 
       //! default ctor/dtor
       HistContent()  {};
@@ -159,12 +160,14 @@ namespace PHEnergyCorrelator {
       HistContent(
         const double w,
         const double l,
-        const double f = 0.
+        const double f = 0.,
+        const int    p = 0
       ) {
-        weight = w;
-        rl     = l;
-        phi    = f;
-      }  // end ctor(double x 3)
+        weight  = w;
+        rl      = l;
+        phi     = f;
+        pattern = p;
+      }  // end ctor(double x 3, int)
 
       //! ctor accepting only 3-point arguments
       HistContent(
@@ -191,16 +194,18 @@ namespace PHEnergyCorrelator {
         const double s,
         const double x,
         const double t,
-        const double f = 0.
+        const double f = 0.,
+        const int    p = 0
       ) {
-        weight = w;
-        rl     = l;
-        rm     = m;
-        rs     = s;
-        xi     = x;
-        theta  = t;
-        phi    = f;
-      }  // end ctor(double x 7)
+        weight  = w;
+        rl      = l;
+        rm      = m;
+        rs      = s;
+        xi      = x;
+        theta   = t;
+        phi     = f;
+        pattern = p;
+      }  // end ctor(double x 7, int x 1)
 
     };  // end HistContent
 

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -142,19 +142,49 @@ namespace PHEnergyCorrelator {
       double rm;
       double rs;
       double xi;
+      double theta;
       double phi;
 
       //! default ctor/dtor
       HistContent()  {};
       ~HistContent() {};
 
-      //! ctor accepting arguments
+      //! ctor accepting only 2-point arguments
       HistContent(
         const double w,
         const double l,
+        const double f = 0.
+      ) {
+        weight = w;
+        rl     = l;
+        phi    = f;
+      }  // end ctor(double x 3)
+
+      //! ctor accepting only 3-point arguments
+      HistContent(
+        const double w,
+        const double x,
+        const double t,
+        const double l,
         const double m = 0.,
-        const double s = 0.,
-        const double x = 0.,
+        const double s = 0.
+      ) {
+        weight = w;
+        xi     = x;
+        theta  = t;
+        rl     = l;
+        rm     = m;
+        rs     = s;
+      }  // end ctor(double x 6)
+
+      //! ctor accepting all arguments
+      HistContent(
+        const double w,
+        const double l,
+        const double m,
+        const double s,
+        const double x,
+        const double t,
         const double f = 0.
       ) {
         weight = w;
@@ -162,8 +192,9 @@ namespace PHEnergyCorrelator {
         rm     = m;
         rs     = s;
         xi     = x;
+        theta  = t;
         phi    = f;
-      }  // end ctor(double x 6)
+      }  // end ctor(double x 7)
 
     };  // end HistContent
 

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -77,19 +77,25 @@ void PHEnergyCorrelatorTest() {
   // --------------------------------------------------------------------------
   // Test calculator
   // --------------------------------------------------------------------------
-  /* TODO changes values to something actually physical,
-   *   these are just random...
+  /*! N.B. the jet/cst values are random: they're here just to
+   *  provide a unit test and make sure everything works.
    */
   std::cout << "    Case [2]: test calculator." << std::endl;
 
-  // pi/4, 5pi/4
+  // pi/4, pi/3, 5pi/4, 4pi/3
   const double piDiv4  = TMath::PiOver4();
+  const double piDiv3  = TMath::Pi() / 3.;
   const double pi5Div4 = 5. * TMath::PiOver4();
+  const double pi4Div3 = 4. * piDiv3;
 
   // jet values
   std::vector<PHEC::Type::Jet> jets;
-  jets.push_back( PHEC::Type::Jet(0.25, 8.0, 0.2, piDiv4, 1.)   );
-  jets.push_back( PHEC::Type::Jet(0.75, 13., -0.2, pi5Div4, 1.) );
+  jets.push_back(
+    PHEC::Type::Jet(0.25, 8.0, 0.2, piDiv4, piDiv3, pi5Div4, 1)
+  );
+  jets.push_back(
+    PHEC::Type::Jet(0.75, 13., -0.2, pi5Div4, piDiv3, pi5Div4, 2)
+  );
 
   // cst values
   std::vector< std::vector< PHEC::Type::Cst > > csts( jets.size() );
@@ -103,8 +109,6 @@ void PHEnergyCorrelatorTest() {
   for (std::size_t ijet = 0; ijet < jets.size(); ++ijet) {
     for (std::size_t icst_a = 0; icst_a < csts[ijet].size(); ++icst_a) {
       for (std::size_t icst_b = 0; icst_b < csts[ijet].size(); ++icst_b) {
-
-        // do calculation
         calc_a.CalcEEC(
           jets[ijet],
           std::make_pair(csts[ijet][icst_a], csts[ijet][icst_b])
@@ -122,7 +126,7 @@ void PHEnergyCorrelatorTest() {
   PHEC::Calculator calc_b(PHEC::Type::Pt);
   calc_b.SetPtJetBins(ptjetbins);
   calc_b.SetCFJetBins(cfjetbins);
-  calc_b.GetManager().DoSpinBins();
+  calc_b.SetDoSpinBins(true);
   calc_b.SetHistTag("SecondTest");
   calc_b.Init(true);
 

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -55,8 +55,7 @@ void PHEnergyCorrelatorTest() {
 
   // cf jet bins
   std::vector< std::pair<float, float> > cfjetbins;
-  cfjetbins.push_back( std::make_pair(0., 0.5) );
-  cfjetbins.push_back( std::make_pair(0.5, 1.) );
+  cfjetbins.push_back( std::make_pair(0.3, 0.6) );
 
   // instantiate calculator
   PHEC::Calculator calc_a(PHEC::Type::Pt);

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -122,6 +122,7 @@ void PHEnergyCorrelatorTest() {
   PHEC::Calculator calc_b(PHEC::Type::Pt);
   calc_b.SetPtJetBins(ptjetbins);
   calc_b.SetCFJetBins(cfjetbins);
+  calc_b.GetManager().DoSpinBins();
   calc_b.SetHistTag("SecondTest");
   calc_b.Init(true);
 

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -105,9 +105,6 @@ void PHEnergyCorrelatorTest() {
     for (std::size_t icst_a = 0; icst_a < csts[ijet].size(); ++icst_a) {
       for (std::size_t icst_b = 0; icst_b < csts[ijet].size(); ++icst_b) {
 
-        // skip diagonal
-        if (icst_a == icst_b) continue;
-
         // do calculation
         calc_a.CalcEEC(
           jets[ijet],
@@ -133,9 +130,6 @@ void PHEnergyCorrelatorTest() {
   for (std::size_t ijet = 0; ijet < jets.size(); ++ijet) {
     for (std::size_t icst_a = 0; icst_a < csts[ijet].size(); ++icst_a) {
       for (std::size_t icst_b = 0; icst_b < csts[ijet].size(); ++icst_b) {
-
-        // skip diagonal
-        if (icst_a == icst_b) continue;
 
         // do calculation
         calc_b.CalcEEC(

--- a/test/jetAna.C
+++ b/test/jetAna.C
@@ -260,8 +260,7 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
    */ 
 
 // define flags to turn off certain calculations
-#define doAllJetEEC 1
-#define doMaxJetCalc 1
+#define doRecoEEC 1
 
   // pt jet bins
   std::vector< std::pair<float, float> > ptJetBins;
@@ -280,18 +279,14 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
   //   - and the 2nd argument is what power we're
   //     going to raise the weights to (by default
   //     it's set to 1.0, the usual EEC definition)
-  PHEC::Calculator allJetEEC( PHEC::Type::Pt, 1.0 ); 
-  PHEC::Calculator maxJetEEC( PHEC::Type::Pt, 1.0 );
+  PHEC::Calculator recoEEC( PHEC::Type::Pt, 1.0 );
 
   // set histogram tags
-  allJetEEC.SetHistTag( "AllJet" );
-  maxJetEEC.SetHistTag( "MaxJet" );
+  recoEEC.SetHistTag( "DataJet" );
 
   // set bins (spin bins are set in a similar way)
-  allJetEEC.SetPtJetBins( ptJetBins );
-  maxJetEEC.SetPtJetBins( ptJetBins );
-  allJetEEC.SetCFJetBins( cfJetBins );
-  maxJetEEC.SetCFJetBins( cfJetBins );
+  recoEEC.SetPtJetBins( ptJetBins );
+  recoEEC.SetCFJetBins( cfJetBins );
 
   // run initialization routine to generate 
   // desired histograms
@@ -301,8 +296,7 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
   //     histograms (TODO)
   //   - and the 3rd argument turns on/off
   //     lambda-tagged EEC histograms (TODO)
-  allJetEEC.Init(true, false, false);
-  maxJetEEC.Init(true, false, false);
+  recoEEC.Init(true, false, false);
 
   // --------------------------------------------------------------------------
  
@@ -880,66 +874,6 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
 
       hVertexJets->Fill(r_vertex);
 
-      // ----------------------------------------------------------------------
-      // EEC calculation over all jets
-      // ----------------------------------------------------------------------
-      /* Here we actually run the relevant calculations
-       * on the jets and their constituents. Note that
-       * if you haven't turned on histograms for a
-       * particular calculation (e.g. the 3-point), then
-       * the code won't try to fill the corresponding
-       * histograms.
-       */
-      if (doAllJetEEC) {
-
-        // loop through jets
-        for (int iJet = 0; iJet < nRecoJets; ++iJet) {
-
-          // collect jet information into a handy struct
-          //   - NOTE: the spin for the bunch x-ing is
-          //     bundled w/ the jets (the last argument)
-          //   - For now, it's just a dummy value
-          PHEC::Type::Jet jet(
-            r_cf[iJet],
-            r_pT[iJet],
-            r_eta[iJet],
-            r_phi[iJet],
-            1.
-          );
-
-          // loop through pairs of constituents
-          for (std::size_t iCstA = 0; iCstA < re_cs_z->at(iJet).size(); ++iCstA) {
-            for (std::size_t iCstB = 0; iCstB < re_cs_z->at(iJet).size(); ++iCstB) {
-
-              // skip diagonal
-              if (iCstA == iCstB) continue;
-
-              // collect cst information into a handy struct
-              PHEC::Type::Cst cstA(
-                re_cs_z->at(iJet).at(iCstA),
-                re_cs_jT->at(iJet).at(iCstA),
-                re_cs_eta->at(iJet).at(iCstA),
-                re_cs_phi->at(iJet).at(iCstA),
-                re_cs_charge->at(iJet).at(iCstA)
-              );
-              PHEC::Type::Cst cstB(
-                re_cs_z->at(iJet).at(iCstB),
-                re_cs_jT->at(iJet).at(iCstB),
-                re_cs_eta->at(iJet).at(iCstB),
-                re_cs_phi->at(iJet).at(iCstB),
-                re_cs_charge->at(iJet).at(iCstB)
-              );
-
-              // run 2-point calculation for pair
-              allJetEEC.CalcEEC( jet, std::make_pair(cstA, cstB) );
-
-            }  // end 2nd cst loop
-          }  // end 1st cst loop
-        }  // end jet loop
-      }  // end all jet eec calculation
-
-      // ----------------------------------------------------------------------
-
       int indexMax = -1;
       if(useML)
         indexMax = GetMaxPtIndex(r_ml_pT, r_cf, r_phi, nRecoJets, RUNNUM, NPTBINS, PTBINS, AcceptFlag);
@@ -1102,7 +1036,7 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
               );
 
               // run 2-point calculation for pair
-              maxJetEEC.CalcEEC( jet, std::make_pair(cstA, cstB) );
+              recoEEC.CalcEEC( jet, std::make_pair(cstA, cstB) );
 
             }  // end 2nd cst loop
           }  // end 1st cst loop
@@ -1445,8 +1379,7 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
    *  method.
    */ 
 
-  if (doAllJetEEC) allJetEEC.End( fOut );
-  if (doMaxJetEEC) maxJetEEC.End( fOut );
+  if (doRecoEEC) recoEEC.End( fOut );
 
   // --------------------------------------------------------------------------
 

--- a/test/jetAna.C
+++ b/test/jetAna.C
@@ -998,7 +998,7 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
          * the code won't try to fill the corresponding
          * histograms.
          */
-        if (doMaxJetEEC) {
+        if (doRecoEEC) {
 
           // collect jet information into a handy struct
           //   - NOTE: the spin for the bunch x-ing is
@@ -1015,9 +1015,6 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
           // loop through pairs of constituents
           for (std::size_t iCstA = 0; iCstA < re_cs_z->at(indexMax).size(); ++iCstA) {
             for (std::size_t iCstB = 0; iCstB < re_cs_z->at(indexMax).size(); ++iCstB) {
-
-              // skip diagonal
-              if (iCstA == iCstB) continue;
 
               // collect cst information into a handy struct
               PHEC::Type::Cst cstA(

--- a/test/jetAna.C
+++ b/test/jetAna.C
@@ -270,8 +270,7 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
 
   // cf jet bins
   std::vector< std::pair<float, float> > cfJetBins;
-  cfJetBins.push_back( std::make_pair(0., 0.5) );
-  cfJetBins.push_back( std::make_pair(0.5, 1.) );
+  cfJetBins.push_back( std::make_pair(0., 1.0) );
 
   // now declare calculators
   //   - the 1st argument is what's going to be used
@@ -991,12 +990,9 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
         // ---------------------------------------------------------------------
         // EEC calculations over max pt jet
         // ---------------------------------------------------------------------
-        /* Here we actually run the relevant calculations
-         * on the jets and their constituents. Note that
-         * if you haven't turned on histograms for a
-         * particular calculation (e.g. the 3-point), then
-         * the code won't try to fill the corresponding
-         * histograms.
+        /* N.B. cuts on jet pt and eta are baked into the requirement
+         *   that max_truth_idx >= 0. A max truth jet has to satisfy
+         *   these cuts.
          */
         if (doRecoEEC) {
 

--- a/test/jetAnaSim.C
+++ b/test/jetAnaSim.C
@@ -800,10 +800,8 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
   // --------------------------------------------------------------------------
 
 // define flags to turn off certain calculations
-#define doAllTrueEEC 1
-#define doMaxTrueEEC 1
-#define doAllRecoEEC 1
-#define doMaxRecoEEC 1
+#define doTrueEEC 1
+#define doRecoEEC 1
 
   // pt jet bins
   std::vector< std::pair<float, float> > ptJetBins;
@@ -817,35 +815,25 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
   cfJetBins.push_back( std::make_pair(0.5, 1.) );
 
   // now declare calculators
-  PHEC::Calculator allTrueCalc( PHEC::Type::Pt, 1.0 );
-  PHEC::Calculator maxTrueCalc( PHEC::Type::Pt, 1.0 );
-  PHEC::Calculator allRecoCalc( PHEC::Type::Pt, 1.0 );
-  PHEC::Calculator maxRecoCalc( PHEC::Type::Pt, 1.0 );
+  PHEC::Calculator trueEEC( PHEC::Type::Pt, 1.0 );
+  PHEC::Calculator recoEEC( PHEC::Type::Pt, 1.0 );
 
   // set histogram tags
-  allTrueCalc.SetHistTag( "AllTrue" );
-  maxTrueCalc.SetHistTag( "MaxTrue" );
-  allRecoCalc.SetHistTag( "AllReco" );
-  maxRecoCalc.SetHistTag( "MaxReco" );
+  trueEEC.SetHistTag( "TrueJet" );
+  recoEEC.SetHistTag( "RecoJet" );
 
   // set pt jet bins
-  allTrueCalc.SetPtJetBins( ptJetBins );
-  maxTrueCalc.SetPtJetBins( ptJetBins );
-  allRecoCalc.SetPtJetBins( ptJetBins );
-  maxRecoCalc.SetPtJetBins( ptJetBins );
+  trueEEC.SetPtJetBins( ptJetBins );
+  recoEEC.SetPtJetBins( ptJetBins );
 
   // set cf bins 
-  allTrueCalc.SetCFJetBins( cfJetBins );
-  maxTrueCalc.SetCFJetBins( cfJetBins );
-  allRecoCalc.SetCFJetBins( cfJetBins );
-  maxRecoCalc.SetCFJetBins( cfJetBins );
+  trueEEC.SetCFJetBins( cfJetBins );
+  recoEEC.SetCFJetBins( cfJetBins );
 
   // run initialization routine to generate 
   // desired histograms
-  allTrueCalc.Init(true, false, false);
-  maxTrueCalc.Init(true, false, false);
-  allRecoCalc.Init(true, false, false);
-  maxRecoCalc.Init(true, false, false);
+  trueEEC.Init(true, false, false);
+  recoEEC.Init(true, false, false);
 
   // --------------------------------------------------------------------------
 
@@ -1862,61 +1850,6 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
 
 #define doTrue 1
 
-      // ----------------------------------------------------------------------
-      // EEC calculation over all truth jets
-      // ----------------------------------------------------------------------
-      if (doTrue && doAllTrueEEC) {
-
-        // loop through jets
-        for (int iTruthJet = 0; iTruthJet < nTruthJets; ++iTruthJet) {
-
-          // collect jet information into a handy struct
-          //   - TODO: calculate the actual charged fraction
-          //     for the truth jets; for now it's just a
-          //     dummy value
-          //   - NOTE: the spin for the bunch x-ing is
-          //     bundled w/ the jets (the last argument)
-          //   - For now, it's just a dummy value
-          PHEC::Type::Jet jet(
-            0.66,
-            t_pT[iTruthJet],
-            t_eta[iTruthJet],
-            t_phi[iTruthJet],
-            1.
-          );
-
-          // loop through pairs of constituents
-          for (std::size_t iTruthCstA = 0; iTruthCstA < tr_cs_z->at(iTruthJet).size(); ++iTruthCstA) {
-            for (std::size_t iTruthCstB = 0; iTruthCstB < tr_cs_z->at(iTruthJet).size(); ++iTruthCstB) {
-
-              // skip diagonal
-              if (iTruthCstA == iTruthCstB) continue;
-
-              // collect cst information into a handy struct
-              PHEC::Type::Cst cstA(
-                tr_cs_z->at(iTruthJet).at(iTruthCstA),
-                tr_cs_jT->at(iTruthJet).at(iTruthCstA),
-                tr_cs_eta->at(iTruthJet).at(iTruthCstA),
-                tr_cs_phi->at(iTruthJet).at(iTruthCstA),
-                tr_cs_charge->at(iTruthJet).at(iTruthCstA)
-              );
-              PHEC::Type::Cst cstB(
-                tr_cs_z->at(iTruthJet).at(iTruthCstB),
-                tr_cs_jT->at(iTruthJet).at(iTruthCstB),
-                tr_cs_eta->at(iTruthJet).at(iTruthCstB),
-                tr_cs_phi->at(iTruthJet).at(iTruthCstB),
-                tr_cs_charge->at(iTruthJet).at(iTruthCstB)
-              );
-
-              // run 2-point calculation for pair
-              allTrueCalc.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
-
-            }  // end 2nd cst loop
-          }  // end 1st cst loop
-        }  // end truth jet loop
-      }  // end all truth jet eec calculation
-
-      // ----------------------------------------------------------------------
 
 	if(doTrue){
 
@@ -1948,7 +1881,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
       // ----------------------------------------------------------------------
       // EEC calculation over max pt truth jets
       // ----------------------------------------------------------------------
-      if (doTrue && doMaxTrueEEC && (max_truth_idx>=0)) {
+      if (doTrue && doTrueEEC && (max_truth_idx>=0)) {
 
         // collect jet information into a handy struct
         //   - TODO: calculate the actual charged fraction
@@ -1989,7 +1922,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
             );
 
             // run 2-point calculation for pair
-            maxTrueCalc.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
+            trueEEC.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
 
           }  // end 2nd cst loop
         }  // end 1st cst loop
@@ -2010,60 +1943,6 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
 	if(nRecoJets > 0){
 
 	  hVertexJets->Fill(vertex,evWeight);
-
-          // ------------------------------------------------------------------
-          // EEC calculation over all reco jets
-          // ------------------------------------------------------------------
-          if (doAllRecoEEC) {
-
-            // loop through jets
-            for (int iRecoJet = 0; iRecoJet < nRecoJets; ++iRecoJet) {
-
-              // collect jet information into a handy struct
-              //     dummy value
-              //   - NOTE: the spin for the bunch x-ing is
-              //     bundled w/ the jets (the last argument)
-              //   - For now, it's just a dummy value
-              PHEC::Type::Jet jet(
-                r_cf[iRecoJet],
-                r_pT[iRecoJet],
-                r_eta[iRecoJet],
-                r_phi[iRecoJet],
-                1.
-              );
-
-              // loop through pairs of constituents
-              for (std::size_t iRecoCstA = 0; iRecoCstA < re_cs_z->at(iRecoJet).size(); ++iRecoCstA) {
-                for (std::size_t iRecoCstB = 0; iRecoCstB < re_cs_z->at(iRecoJet).size(); ++iRecoCstB) {
-
-                  // skip diagonal
-                  if (iRecoCstA == iRecoCstB) continue;
-
-                  // collect cst information into a handy struct
-                  PHEC::Type::Cst cstA(
-                    re_cs_z->at(iRecoJet).at(iRecoCstA),
-                    re_cs_jT->at(iRecoJet).at(iRecoCstA),
-                    re_cs_eta->at(iRecoJet).at(iRecoCstA),
-                    re_cs_phi->at(iRecoJet).at(iRecoCstA),
-                    re_cs_charge->at(iRecoJet).at(iRecoCstA)
-                  );
-                  PHEC::Type::Cst cstB(
-                    re_cs_z->at(iRecoJet).at(iRecoCstB),
-                    re_cs_jT->at(iRecoJet).at(iRecoCstB),
-                    re_cs_eta->at(iRecoJet).at(iRecoCstB),
-                    re_cs_phi->at(iRecoJet).at(iRecoCstB),
-                    re_cs_charge->at(iRecoJet).at(iRecoCstB)
-                  );
-
-                  // run 2-point calculation for pair
-                  allRecoCalc.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
-
-                }  // end 2nd cst loop
-              }  // end 1st cst loop
-            }  // end reco jet loop
-          }  // end all reco jet eec calculation
-
-          // ------------------------------------------------------------------
 
 	  int indexMax = -1;
 	  if(useML)
@@ -2121,7 +2000,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
           // ------------------------------------------------------------------
           // EEC calculation over max pt reco jets
           // ------------------------------------------------------------------
-          if (doMaxRecoEEC) {
+          if (doRecoEEC) {
 
             // collect jet information into a handy struct
             //     dummy value
@@ -2160,7 +2039,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
                 );
 
                 // run 2-point calculation for pair
-                maxRecoCalc.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
+                recoEEC.CalcEEC( jet, std::make_pair(cstA, cstB), evWeight );
 
               }  // end 2nd cst loop
             }  // end 1st cst loop
@@ -2646,10 +2525,8 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
   // EEC calculations
   // --------------------------------------------------------------------------
 
-  if (doTrue && doAllTrueEEC) allTrueCalc.End( fOut );
-  if (doTrue && doMaxTrueEEC) maxTrueCalc.End( fOut );
-  if (doAllRecoEEC)           allRecoCalc.End( fOut );
-  if (doMaxRecoEEC)           maxRecoCalc.End( fOut );
+  if (doTrue && doTrueEEC) trueEEC.End( fOut );
+  if (doRecoEEC)           recoEEC.End( fOut );
 
   // --------------------------------------------------------------------------
 

--- a/test/jetAnaSim.C
+++ b/test/jetAnaSim.C
@@ -811,8 +811,7 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
 
   // cf jet bins
   std::vector< std::pair<float, float> > cfJetBins;
-  cfJetBins.push_back( std::make_pair(0., 0.5) );
-  cfJetBins.push_back( std::make_pair(0.5, 1.) );
+  cfJetBins.push_back( std::make_pair(0., 1.0) );
 
   // now declare calculators
   PHEC::Calculator trueEEC( PHEC::Type::Pt, 1.0 );
@@ -1881,17 +1880,18 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
       // ----------------------------------------------------------------------
       // EEC calculation over max pt truth jets
       // ----------------------------------------------------------------------
+      /* N.B. cuts on jet pt and eta are baked into the requirement
+       *   that max_truth_idx >= 0. A max truth jet has to satisfy
+       *   these cuts.
+       */
       if (doTrue && doTrueEEC && (max_truth_idx>=0)) {
 
         // collect jet information into a handy struct
-        //   - TODO: calculate the actual charged fraction
-        //     for the truth jets; for now it's just a
-        //     dummy value
         //   - NOTE: the spin for the bunch x-ing is
         //     bundled w/ the jets (the last argument)
         //   - For now, it's just a dummy value
         PHEC::Type::Jet jet(
-          0.51,
+          0.51,  // dummy value, not binning on cf
           t_pT[max_truth_idx],
           t_eta[max_truth_idx],
           t_phi[max_truth_idx],
@@ -1997,10 +1997,12 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
           // ------------------------------------------------------------------
           // EEC calculation over max pt reco jets
           // ------------------------------------------------------------------
+          /* N.B. cuts on jet pt, eta, and CNF are baked into the requirement
+           *   that indexMax >= 0. A max reco jet has to satisfy these cuts.
+           */
           if (doRecoEEC) {
 
             // collect jet information into a handy struct
-            //     dummy value
             //   - NOTE: the spin for the bunch x-ing is
             //     bundled w/ the jets (the last argument)
             //   - For now, it's just a dummy value

--- a/test/jetAnaSim.C
+++ b/test/jetAnaSim.C
@@ -1902,9 +1902,6 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
         for (std::size_t iTruthCstA = 0; iTruthCstA < tr_cs_z->at(max_truth_idx).size(); ++iTruthCstA) {
           for (std::size_t iTruthCstB = 0; iTruthCstB < tr_cs_z->at(max_truth_idx).size(); ++iTruthCstB) {
 
-            // skip diagonal
-            if (iTruthCstA == iTruthCstB) continue;
-
             // collect cst information into a handy struct
             PHEC::Type::Cst cstA(
               tr_cs_z->at(max_truth_idx).at(iTruthCstA),
@@ -2018,9 +2015,6 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
             // loop through pairs of constituents
             for (std::size_t iRecoCstA = 0; iRecoCstA < re_cs_z->at(indexMax).size(); ++iRecoCstA) {
               for (std::size_t iRecoCstB = 0; iRecoCstB < re_cs_z->at(indexMax).size(); ++iRecoCstB) {
-
-                // skip diagonal
-                if (iRecoCstA == iRecoCstB) continue;
 
                 // collect cst information into a handy struct
                 PHEC::Type::Cst cstA(


### PR DESCRIPTION
This PR implements several changes in preparation for investigating spin-dependent EECs. Spin information is included with the `PHEC::Type::Jet` class where the user can provide the spin pattern (`r_spinPat`) and the blue & yellow spin angles (`bluePhiSpin`, `yellowPhiSpin`).

When spin sorting is turned on, histograms will be binned according to the polarization of each beam:
1. Blue up,
2. Blue down,
3. Yellow up,
4. Yellow down,
5. And integrated.
The relevant histograms will be filled by `PHEC::PHCorrelatorCalculator` based on the provided spin pattern.

Note that in wiring in the spin information, the EEC calculations in both `jetAnaSim.C` and `jetAna.C` have been moved to AFTER the vertex cut and AFTER the condition that we're only considering runs 12 or 15 and not heavy ion beams/embedding.

### Changes
- [x] Remove calculations over all jets in both `jetAnaSim.C` and in `jetAna.C`
- [x] Include self-correlations
- [x] Remove additional cuts on jet CF
- [x] Add spin-dependent histograms
- [x] Index histograms over spin (blue up, blue down, yellow up, yellow down)
- [x] Implement spin calculations