### PR TITLE
Extend spin sorting

### DIFF
--- a/include/PHCorrelatorBins.h
+++ b/include/PHCorrelatorBins.h
@@ -98,6 +98,7 @@ namespace PHEnergyCorrelator {
         m_bins["cosangle"] = Binning(20, -1., 1.);
         m_bins["xi"]       = Binning(100, 0., 1.);
         m_bins["pattern"]  = Binning(10, -0.5, 9.5);
+        m_bins["spin"]     = Binning(5, -2.5, 2.5);
 
       }  // end 'ctor()'
 

--- a/include/PHCorrelatorBins.h
+++ b/include/PHCorrelatorBins.h
@@ -97,7 +97,7 @@ namespace PHEnergyCorrelator {
         m_bins["angle"]    = Binning(180, -3.15, 3.15);
         m_bins["cosangle"] = Binning(20, -1., 1.);
         m_bins["xi"]       = Binning(100, 0., 1.);
-        m_bins["pattern"]  = Binning(5, -0.5, 4.5);
+        m_bins["pattern"]  = Binning(10, -0.5, 9.5);
 
       }  // end 'ctor()'
 

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -298,38 +298,39 @@ namespace PHEnergyCorrelator {
       ) {
 
         // get jet 4-momenta
-        TLorentzVector jet_vec = Tools::GetJetLorentz(jet);
+        TLorentzVector vecJet4  = Tools::GetJetLorentz(jet, false);
+        TLorentzVector unitJet4 = Tools::GetJetLorentz(jet, true);
 
         // get cst 4-momenta
-        std::pair<TLorentzVector, TLorentzVector> cst_vecs = std::make_pair(
-          Tools::GetCstLorentz(jet_vec.Vect(), csts.first),
-          Tools::GetCstLorentz(jet_vec.Vect(), csts.second)
+        std::pair<TLorentzVector, TLorentzVector> vecCst4 = std::make_pair(
+          Tools::GetCstLorentz(csts.first, jet.pt),
+          Tools::GetCstLorentz(csts.second, jet.pt)
         );
 
-        // get vector distance b/n average of cst.s and spin direction
-        TLorentzVector cst_avg = Tools::GetWeightedAvgLorentz(
-          cst_vecs.first,
-          cst_vecs.second
+        // get average of cst 3-vectors
+        TVector3 avgCst3 = Tools::GetWeightedAvgVector(
+          vecCst4.first.Vect(),
+          vecCst4.second.Vect()
         );
 
-        // now get weights
+        // now get EEC weights
         std::pair<double, double> cst_weights = std::make_pair(
-          GetCstWeight(cst_vecs.first, jet_vec),
-          GetCstWeight(cst_vecs.second, jet_vec)
+          GetCstWeight(vecCst4.first, vecJet4),
+          GetCstWeight(vecCst4.second, vecJet4)
         );
 
         // calculate RL (dist b/n cst.s for EEC), EEC, and
         // angle b/n the cst average and spin
         const double dist    = Tools::GetCstDist(csts);
         const double weight  = cst_weights.first * cst_weights.second * evt_weight;
-        const double dphiblu = remainder(cst_avg.Phi() - jet.phiblu, TMath::TwoPi());
-        const double dphiyel = remainder(cst_avg.Phi() - jet.phiyel, TMath::TwoPi());
+        const double dphiblu = remainder(avgCst3.Phi() - jet.phiblu, TMath::TwoPi());
+        const double dphiyel = remainder(avgCst3.Phi() - jet.phiyel, TMath::TwoPi());
 
         // fill histograms if needed
         //   - FIXME this can be simplified...
         if (m_manager.GetDoEECHists()) {
 
-          // grab hist indices; if doing spin binning, the order
+          // grab hist indices
           std::vector<Type::HistIndex> indices = GetHistIndices(jet);
 
           // fill spin integrated case

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -36,21 +36,6 @@ namespace PHEnergyCorrelator {
   // ==========================================================================
   class Calculator {
 
-    public:
-
-      // ----------------------------------------------------------------------
-      //! Possible spin patterns
-      // ----------------------------------------------------------------------
-      enum pattern {
-        PPBUYU = 0,  /*!< blue up, yellow up (pp) */
-        PPBDYU = 1,  /*!< blue down, yellow up (pp) */
-        PPBUYD = 2,  /*!< blue up, yellow down (pp) */
-        PPBDYD = 3,  /*!< blue down, yellow down (pp) */
-        PABU   = 4,  /*!< blue up (pAu) */
-        PABD   = 5   /*!< blue down (pAu) */
-      };
-
-
     private:
 
       // data members (calc options)
@@ -161,46 +146,47 @@ namespace PHEnergyCorrelator {
             switch (jet.pattern) {
 
               // blue up, yellow up (pp)
-              case PPBUYU:
+              case Type::PPBUYU:
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BU) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YU) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BUYU) );
                 break;
 
               // blue down, yellow up (pp)
-              case PPBDYU:
+              case Type::PPBDYU:
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BD) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YU) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BDYU) );
                 break;
 
               // blue up, yellow down (pp)
-              case PPBUYD:
+              case Type::PPBUYD:
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BU) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YD) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BUYD) );
                 break;
 
               // blue down, yellow down (pp)
-              case PPBDYD:
+              case Type::PPBDYD:
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BD) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YD) );
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BDYD) );
                 break;
 
               // blue up (pAu)
-              case PABU:
+              case Type::PABU:
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BU) );
                 break;
 
               // blue down (pAu)
-              case PABD:
+              case Type::PABD:
                 indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BD) );
                 break;
 
               // by default, only add integrated
               default:
                 break;
+
           }
         }
         return indices;

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -330,70 +330,48 @@ namespace PHEnergyCorrelator {
         if (phiJetBlue > TMath::PiOver2()) phiJetBlue -= TMath::Pi();
         if (phiJetYell > TMath::PiOver2()) phiJetYell -= TMath::Pi();
 
-        // now get EEC weights
+        // get EEC weights
         std::pair<double, double> cst_weights = std::make_pair(
           GetCstWeight(vecCst4.first, vecJet4),
           GetCstWeight(vecCst4.second, vecJet4)
         );
 
-        // then calculate RL (dist b/n cst.s for EEC) and overall EEC weight
+        // and then calculate RL (dist b/n cst.s for EEC) and overall EEC weight
         const double dist    = Tools::GetCstDist(csts);
         const double weight  = cst_weights.first * cst_weights.second * evt_weight;
 
         // fill histograms if needed
-        //   - FIXME this can be simplified...
         if (m_manager.GetDoEECHists()) {
 
           // grab hist indices
           std::vector<Type::HistIndex> indices = GetHistIndices(jet);
 
-          // fill spin integrated case
-          Type::HistContent content_int(weight, dist);
-          m_manager.FillEECHists(indices[0], content_int);
+          // collect quantities to be histogrammed
+          Type::HistContent content(
+            weight,
+            dist,
+            phiHadBlue,
+            phiHadYell,
+            phiJetBlue,
+            phiJetYell,
+            vecSpin3.first.Y(),
+            vecSpin3.second.y(),
+            jet.pattern
+          );
+
+          // fill spin-integrated histograms
+          m_manager.FillEECHists(indices[0], content);
 
           // if needed, fill spin sorted histograms
           if (m_manager.GetDoSpinBins() && (indices.size() > 1)) {
 
             // fill blue-only case
-            Type::HistContent content_blu(
-              weight,
-              dist,
-              phiHadBlue,
-              std::numeric_limits<double>::max(),
-              phiJetBlue,
-              std::numeric_limits<double>::max(),
-              vecSpin3.first.Y(),
-              vecSpin3.second.Y(),
-              jet.pattern
-            );
-            m_manager.FillEECHists(indices[1], content_blu);
+            m_manager.FillEECHists(indices[1], content);
 
             // fill yellow-only, both cases
             if (indices.size() > 2) {
-              Type::HistContent content_yel(
-                weight,
-                dist,
-                std::numeric_limits<double>::max(),
-                phiHadYell,
-                std::numeric_limits<double>::max(),
-                phiJetYell,
-                vecSpin3.first.Y(),
-                vecSpin3.second.Y(),
-                jet.pattern
-              );
-              Type::HistContent content_both(
-                weight,
-                dist,
-                phiHadBlue,
-                phiHadYell,
-                phiJetBlue,
-                phiJetYell,
-                vecSpin3.first.Y(),
-                vecSpin3.second.Y(),
-                jet.pattern
-              );
-              m_manager.FillEECHists(indices[2], content_yel);
-              m_manager.FillEECHists(indices[3], content_both);
+              m_manager.FillEECHists(indices[2], content);
+              m_manager.FillEECHists(indices[3], content);
             }
           }  // end spin hist filling
         }  // end hist filing

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -125,12 +125,12 @@ namespace PHEnergyCorrelator {
 
         // but for spin, we'll have 2 indices
         // for each spin pattern
-        //   - pattern = 1 --> spin indices = {0, 3}
-        //   - pattern = 2 --> spin indices = {1, 2}
-        //   - pattern = 3 --> spin indices = {1, 3}
-        //   - pattern = 4 --> spin indices = {0, 2}
+        //   - pattern = 1 --> spin indices = {BU, YD}
+        //   - pattern = 2 --> spin indices = {BD, YU}
+        //   - pattern = 3 --> spin indices = {BD, YD}
+        //   - pattern = 4 --> spin indices = {BU, YU}
         // plus the index for integrating over
-        // spins (sp = 4)
+        // spins (sp = Int)
         std::vector<Type::HistIndex> indices;
 
         // determine spin bins
@@ -139,26 +139,26 @@ namespace PHEnergyCorrelator {
 
               // blue up, yellow down
               case 1:
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 0) );
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 3) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BU) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YD) );
                 break;
 
               // blue down, yellow up
               case 2:
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 1) );
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 2) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BD) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YU) );
                 break;
 
               // blue down, yellow down
               case 3:
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 1) );
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 3) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BD) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YD) );
                 break;
 
               // blue up, yellow up
               case 4:
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 0) );
-                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 2) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::BU) );
+                indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::YU) );
                 break;
 
               // by default, only add integrated
@@ -166,7 +166,7 @@ namespace PHEnergyCorrelator {
                 break;
           }
         }
-        indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, 4) );
+        indices.push_back( Type::HistIndex(iptcf.pt, iptcf.cf, Manager::Int) );
         return indices;
 
       }  // end 'GetHistIndices(Type::Jet&)'

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -14,7 +14,6 @@
 // c++ utilities
 #include <algorithm>
 #include <cmath>
-#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -347,28 +346,23 @@ namespace PHEnergyCorrelator {
           std::vector<Type::HistIndex> indices = GetHistIndices(jet);
 
           // collect quantities to be histogrammed
-          Type::HistContent content(
-            weight,
-            dist,
-            phiHadBlue,
-            phiHadYell,
-            phiJetBlue,
-            phiJetYell,
-            vecSpin3.first.Y(),
-            vecSpin3.second.y(),
-            jet.pattern
-          );
+          Type::HistContent content(weight, dist);
+          if (m_manager.GetDoSpinBins()) {
+            content.phiHAvgB = phiHadBlue;
+            content.phiHAvgY = phiHadYell;
+            content.phiCollB = phiJetBlue;
+            content.phiCollY = phiJetYell;
+            content.spinB    = vecSpin3.first.Y();
+            content.spinY    = vecSpin3.second.y();
+            content.pattern  = jet.pattern;
+          }
 
           // fill spin-integrated histograms
           m_manager.FillEECHists(indices[0], content);
 
           // if needed, fill spin sorted histograms
           if (m_manager.GetDoSpinBins() && (indices.size() > 1)) {
-
-            // fill blue-only case
             m_manager.FillEECHists(indices[1], content);
-
-            // fill yellow-only, both cases
             if (indices.size() > 2) {
               m_manager.FillEECHists(indices[2], content);
               m_manager.FillEECHists(indices[3], content);

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -313,18 +313,21 @@ namespace PHEnergyCorrelator {
           vecCst4.second.Vect()
         );
 
+        // compute angles wrt to spins
+        //   - FIXME dummy calculations! need to fill in
+        //     actual calculations wrt to spin!
+        const double dphiblu = remainder(avgCst3.Phi() - vecJet4.Phi(), TMath::TwoPi());
+        const double dphiyel = remainder(avgCst3.Phi() - vecJet4.Phi(), TMath::TwoPi());
+
         // now get EEC weights
         std::pair<double, double> cst_weights = std::make_pair(
           GetCstWeight(vecCst4.first, vecJet4),
           GetCstWeight(vecCst4.second, vecJet4)
         );
 
-        // calculate RL (dist b/n cst.s for EEC), EEC, and
-        // angle b/n the cst average and spin
+        // calculate RL (dist b/n cst.s for EEC) and overall EEC weight
         const double dist    = Tools::GetCstDist(csts);
         const double weight  = cst_weights.first * cst_weights.second * evt_weight;
-        const double dphiblu = remainder(avgCst3.Phi() - jet.phiblu, TMath::TwoPi());
-        const double dphiyel = remainder(avgCst3.Phi() - jet.phiyel, TMath::TwoPi());
 
         // fill histograms if needed
         //   - FIXME this can be simplified...
@@ -346,6 +349,8 @@ namespace PHEnergyCorrelator {
               dist,
               dphiblu,
               std::numeric_limits<double>::max(),
+              dphiblu,
+              std::numeric_limits<double>::max(),
               jet.pattern
             );
             m_manager.FillEECHists(indices[1], content_blu);
@@ -357,11 +362,15 @@ namespace PHEnergyCorrelator {
                 dist,
                 std::numeric_limits<double>::max(),
                 dphiyel,
+                std::numeric_limits<double>::max(),
+                dphiyel,
                 jet.pattern
               );
               Type::HistContent content_both(
                 weight,
                 dist,
+                dphiblu,
+                dphiyel,
                 dphiblu,
                 dphiyel,
                 jet.pattern

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -299,6 +299,9 @@ namespace PHEnergyCorrelator {
           vecCst4.second.Vect()
         );
 
+        // get spins
+        std::pair<TVector3, TVector3> vecSpin3 = Tools::GetSpins( jet.pattern );
+
         // compute angles wrt to spins
         //   - FIXME dummy calculations! need to fill in
         //     actual calculations wrt to spin!
@@ -337,6 +340,8 @@ namespace PHEnergyCorrelator {
               std::numeric_limits<double>::max(),
               dphiblu,
               std::numeric_limits<double>::max(),
+              vecSpin3.first.Y(),
+              vecSpin3.second.Y(),
               jet.pattern
             );
             m_manager.FillEECHists(indices[1], content_blu);
@@ -350,6 +355,8 @@ namespace PHEnergyCorrelator {
                 dphiyel,
                 std::numeric_limits<double>::max(),
                 dphiyel,
+                vecSpin3.first.Y(),
+                vecSpin3.second.Y(),
                 jet.pattern
               );
               Type::HistContent content_both(
@@ -359,6 +366,8 @@ namespace PHEnergyCorrelator {
                 dphiyel,
                 dphiblu,
                 dphiyel,
+                vecSpin3.first.Y(),
+                vecSpin3.second.Y(),
                 jet.pattern
               );
               m_manager.FillEECHists(indices[2], content_yel);

--- a/include/PHCorrelatorConstants.h
+++ b/include/PHCorrelatorConstants.h
@@ -12,6 +12,7 @@
 #define PHCORRELATORCONSTANTS_H
 
 // c++ utilities
+#include <limits>
 #include <string>
 // root libraries
 #include <TVector3.h>
@@ -24,6 +25,30 @@ namespace PHEnergyCorrelator {
   //! PHEnergyCorrelator Constants
   // ==========================================================================
   namespace Const {
+
+    // ------------------------------------------------------------------------
+    // Default value for index arguments
+    // ------------------------------------------------------------------------
+    inline std::size_t IndexDefault() {
+      const std::size_t def = 0;
+      return def;
+    }
+
+    // ------------------------------------------------------------------------
+    // Default value for int arguments
+    // ------------------------------------------------------------------------
+    inline int IntDefault() {
+      const int def = std::numeric_limits<int>::max();
+      return def;
+    }
+
+    // ------------------------------------------------------------------------
+    // Default value for double arguments
+    // ------------------------------------------------------------------------
+    inline double DoubleDefault() {
+      const int def = std::numeric_limits<double>::max();
+      return def;
+    }
 
     // ------------------------------------------------------------------------
     //! Base for log axes

--- a/include/PHCorrelatorConstants.h
+++ b/include/PHCorrelatorConstants.h
@@ -13,6 +13,8 @@
 
 // c++ utilities
 #include <string>
+// root libraries
+#include <TVector3.h>
 
 
 
@@ -53,6 +55,30 @@ namespace PHEnergyCorrelator {
     inline std::string SpinTag() {
       const std::string sptag = "sp";
       return sptag;
+    }
+
+    // ------------------------------------------------------------------------
+    //! Spin up in lab coordinates
+    // ------------------------------------------------------------------------
+    inline TVector3 SpinUp() {
+      const TVector3 up(0.0, 1.0, 0.0);
+      return up;
+    }
+
+    // ------------------------------------------------------------------------
+    //! Spin down in lab coordinates
+    // ------------------------------------------------------------------------
+    inline TVector3 SpinDown() {
+      const TVector3 down(0.0, -1.0, 0.0);
+      return down;
+    }
+
+    // ------------------------------------------------------------------------
+    //! Null spin in lab coordinates
+    // ------------------------------------------------------------------------
+    inline TVector3 SpinNull() {
+      const TVector3 null(0.0, 0.0, 0.0);
+      return null;
     }
 
   }   // end Const namespace

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -268,6 +268,12 @@ namespace PHEnergyCorrelator {
           Histogram("EECWidth", "", "R_{L}", m_bins.Get("side"))
         );
         def_1d.push_back(
+          Histogram("SpinBlue", "", "y_{B}^{spin}", m_bins.Get("spin"))
+        );
+        def_1d.push_back(
+          Histogram("SpinYellow", "", "y_{Y}^{spin}", m_bins.Get("spin"))
+        );
+        def_1d.push_back(
           Histogram("SpinPattern", "", "pattern", m_bins.Get("pattern"))
         );
         def_1d.push_back(
@@ -437,6 +443,8 @@ namespace PHEnergyCorrelator {
         // fill 1d histograms
         m_hist_1d[MakeHistName("EECStat", tag)] -> Fill(content.rl, content.weight);
         m_hist_1d[MakeHistName("EECWidth", tag)] -> Fill(content.rl, content.weight);
+        m_hist_1d[MakeHistName("SpinBlue", tag)] -> Fill(content.spinB);
+        m_hist_1d[MakeHistName("SpinYellow", tag)] -> Fill(content.spinY);
         m_hist_1d[MakeHistName("SpinPattern", tag)] -> Fill(content.pattern);
         m_hist_1d[MakeHistName("SpinHadAvgBlueStat", tag)] -> Fill(content.phiHAvgB);
         m_hist_1d[MakeHistName("SpinHadAvgYellStat", tag)] -> Fill(content.phiHAvgY);

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -253,34 +253,68 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       void GenerateEECHists() {
 
+        // 1d spin axis titles
+        const std::string hadAvgB_title("#varphi_{B}^{#LThh#GT}");
+        const std::string hadAvgY_title("#varphi_{Y}^{#LThh#GT}");
+        const std::string collB_title("#varphi_{B}^{collins}");
+        const std::string collY_title("#varphi_{Y}^{collins}");
+
         // 1d histogram definitions
         std::vector<Histogram> def_1d;
-        def_1d.push_back(Histogram("EECStat", "", "R_{L}", m_bins.Get("side")));
-        def_1d.push_back(Histogram("EECWidth", "", "R_{L}", m_bins.Get("side")));
-        def_1d.push_back(Histogram("SpinPattern", "", "pattern", m_bins.Get("pattern")));
-        def_1d.push_back(Histogram("SpinPhiBlueStat", "", "#varphi_{B}", m_bins.Get("angle")));
-        def_1d.push_back(Histogram("SpinPhiYellStat", "", "#varphi_{Y}", m_bins.Get("angle")));
+        def_1d.push_back(
+          Histogram("EECStat", "", "R_{L}", m_bins.Get("side"))
+        );
+        def_1d.push_back(
+          Histogram("EECWidth", "", "R_{L}", m_bins.Get("side"))
+        );
+        def_1d.push_back(
+          Histogram("SpinPattern", "", "pattern", m_bins.Get("pattern"))
+        );
+        def_1d.push_back(
+          Histogram("SpinHadAvgBlueStat", "", hadAvgB_title, m_bins.Get("angle"))
+        );
+        def_1d.push_back(
+          Histogram("SpinHadAvgYellStat", "", hadAvgY_title, m_bins.Get("angle"))
+        );
+        def_1d.push_back(
+          Histogram("SpinCollinsBlueStat", "", collB_title, m_bins.Get("angle"))
+        );
+        def_1d.push_back(
+          Histogram("SpinCollinsYellStat", "", collY_title, m_bins.Get("angle"))
+        );
 
         // vectors of binnings for 2d histograms
-        std::vector<Binning> spinside_bins;
-        spinside_bins.push_back(m_bins.Get("side"));
-        spinside_bins.push_back(m_bins.Get("angle"));
+        std::vector<Binning> angleXside_bins;
+        angleXside_bins.push_back(m_bins.Get("side"));
+        angleXside_bins.push_back(m_bins.Get("angle"));
 
         // vectors of axis titles for 2d histograms
-        std::vector<std::string> spinsideb_titles;
-        std::vector<std::string> spinsidey_titles;
-        spinsideb_titles.push_back("R_{L}");
-        spinsideb_titles.push_back("#varphi_{B}");
-        spinsidey_titles.push_back("R_{L}");
-        spinsidey_titles.push_back("#varphi_{Y}");
+        std::vector<std::string> hadAvgXsideB_titles;
+        std::vector<std::string> hadAvgXsideY_titles;
+        std::vector<std::string> collXsideB_titles;
+        std::vector<std::string> collXsideY_titles;
+        hadAvgXsideB_titles.push_back("R_{L}");
+        hadAvgXsideB_titles.push_back(hadAvgB_title);
+        hadAvgXsideY_titles.push_back("R_{L}");
+        hadAvgXsideY_titles.push_back(hadAvgY_title);
+        collXsideB_titles.push_back("R_{L}");
+        collXsideB_titles.push_back(collB_title);
+        collXsideY_titles.push_back("R_{L}");
+        collXsideY_titles.push_back(collY_title);
 
         // 2D histogram definitions
         std::vector<Histogram> def_2d;
         def_2d.push_back(
-          Histogram("EECPhiBlueVsRStat", "", spinsideb_titles, spinside_bins)
+          Histogram("EECHadAvgBlueVsRStat", "", hadAvgXsideB_titles, angleXside_bins)
         );
         def_2d.push_back(
-          Histogram("EECPhiYellVsRStat", "", spinsidey_titles, spinside_bins)
+          Histogram("EECHadAvgYellVsRStat", "", hadAvgXsideY_titles, angleXside_bins)
+        );
+        def_2d.push_back(
+          Histogram("EECCollinsBlueVsRStat", "", collXsideB_titles, angleXside_bins)
+        );
+        def_2d.push_back(
+          Histogram("EECCollinsYellVsRStat", "", collXsideY_titles, angleXside_bins)
         );
 
         // create histograms
@@ -404,15 +438,23 @@ namespace PHEnergyCorrelator {
         m_hist_1d[MakeHistName("EECStat", tag)] -> Fill(content.rl, content.weight);
         m_hist_1d[MakeHistName("EECWidth", tag)] -> Fill(content.rl, content.weight);
         m_hist_1d[MakeHistName("SpinPattern", tag)] -> Fill(content.pattern);
-        m_hist_1d[MakeHistName("SpinPhiBlueStat", tag)] -> Fill(content.phib);
-        m_hist_1d[MakeHistName("SpinPhiYellStat", tag)] -> Fill(content.phiy);
+        m_hist_1d[MakeHistName("SpinHadAvgBlueStat", tag)] -> Fill(content.phiHAvgB);
+        m_hist_1d[MakeHistName("SpinHadAvgYellStat", tag)] -> Fill(content.phiHAvgY);
+        m_hist_1d[MakeHistName("SpinCollinsBlueStat", tag)] -> Fill(content.phiCollB);
+        m_hist_1d[MakeHistName("SpinCollinsYellStat", tag)] -> Fill(content.phiCollY);
 
         // fill 2d histograms
-        m_hist_2d[MakeHistName("EECPhiBlueVsRStat", tag)] -> Fill(
-          content.rl, content.phib, content.weight
+        m_hist_2d[MakeHistName("EECHadAvgBlueVsRStat", tag)] -> Fill(
+          content.rl, content.phiHAvgB, content.weight
         );
-        m_hist_2d[MakeHistName("EECPhiYellVsRStat", tag)] -> Fill(
-          content.rl, content.phiy, content.weight
+        m_hist_2d[MakeHistName("EECHadAvgYellVsRStat", tag)] -> Fill(
+          content.rl, content.phiHAvgY, content.weight
+        );
+        m_hist_2d[MakeHistName("EECCollinsBlueVsRStat", tag)] -> Fill(
+          content.rl, content.phiCollB, content.weight
+        );
+        m_hist_2d[MakeHistName("EECCollinsYellVsRStat", tag)] -> Fill(
+          content.rl, content.phiCollY, content.weight
         );
         return;
 

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -52,20 +52,17 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Indices of spin configurations
       // ----------------------------------------------------------------------
-      /*! This enum indexes all possible spin configurations.
-       *  They are
-       *
-       *    0. Int:  integrated over spin
-       *    1. BU:   blue up (int. over yellow)
-       *    2. BD:   blue down (int. over yellow)
-       *    3. YU:   yellow up (int. over blue)
-       *    4. YD:   yellow down (int. over blue)
-       *    5. BUYU: blue up, yellow up
-       *    6. BUYD: blue up, yellow down
-       *    7. BDYU: blue down, yellow up
-       *    8. BDYD: blue down, yellow down
-       */
-      enum Spin {Int, BU, BD, YU, YD, BUYU, BUYD, BDYU, BDYD}; 
+      enum Spin {
+        Int  = 0,  /*!< integrated over spin */
+        BU   = 1,  /*!< blue up (int. over yellow) */
+        BD   = 2,  /*!< blue down (int. over yellow) */
+        YU   = 3,  /*!< yellow up (int. over blue) */
+        YD   = 4,  /*!< yellow down (int. over blue) */
+        BUYU = 5,  /*!< blue up, yellow up */
+        BUYD = 6,  /*!< blue up, yellow up */
+        BDYU = 7,  /*!< blue down, yellow up */
+        BDYD = 8   /*!< blue down, yellow down */
+      };
 
     private:
 
@@ -104,7 +101,8 @@ namespace PHEnergyCorrelator {
       //! Translate spin index into a tag
       // ----------------------------------------------------------------------
       /*! Spin "bins" correspond to different combinations of
-       *  blue/yellow polarizations.
+       *  blue/yellow polarizations, indexed by the enum `Spin`.
+       *  They are
        */ 
       std::string GetSpinTag(const std::size_t isp) const {
 
@@ -114,16 +112,28 @@ namespace PHEnergyCorrelator {
             tag = "Int";
             break;
           case BU:
-            tag = "BlueUp";
+            tag = "BU";
             break;
           case BD:
-            tag = "BlueDown";
+            tag = "BD";
             break;
           case YU:
-            tag = "YellUp";
+            tag = "YU";
             break;
           case YD:
-            tag = "YellDown";
+            tag = "YD";
+            break;
+          case BUYU:
+            tag = "BUYU";
+            break;
+          case BUYD:
+            tag = "BUYD";
+            break;
+          case BDYU:
+            tag = "BDYU";
+            break;
+          case BDYD:
+            tag = "BDYD";
             break;
           default:
             tag = "";
@@ -247,34 +257,30 @@ namespace PHEnergyCorrelator {
         std::vector<Histogram> def_1d;
         def_1d.push_back(Histogram("EECStat", "", "R_{L}", m_bins.Get("side")));
         def_1d.push_back(Histogram("EECWidth", "", "R_{L}", m_bins.Get("side")));
-        def_1d.push_back(Histogram("LogEECStat", "", "log R_{L}", m_bins.Get("logside")));
-        def_1d.push_back(Histogram("LogEECWidth", "", "log R_{L}", m_bins.Get("logside")));
         def_1d.push_back(Histogram("SpinPattern", "", "pattern", m_bins.Get("pattern")));
-        def_1d.push_back(Histogram("SpinPhiStat", "", "#varphi", m_bins.Get("angle")));
+        def_1d.push_back(Histogram("SpinPhiBlueStat", "", "#varphi_{B}", m_bins.Get("angle")));
+        def_1d.push_back(Histogram("SpinPhiYellStat", "", "#varphi_{Y}", m_bins.Get("angle")));
 
         // vectors of binnings for 2d histograms
         std::vector<Binning> spinside_bins;
-        std::vector<Binning> spinlogside_bins;
         spinside_bins.push_back(m_bins.Get("side"));
         spinside_bins.push_back(m_bins.Get("angle"));
-        spinlogside_bins.push_back(m_bins.Get("logside"));
-        spinlogside_bins.push_back(m_bins.Get("angle"));
 
         // vectors of axis titles for 2d histograms
-        std::vector<std::string> spinside_titles;
-        std::vector<std::string> spinlogside_titles;
-        spinside_titles.push_back("R_{L}");
-        spinside_titles.push_back("#varphi");
-        spinlogside_titles.push_back("log R_{L}");
-        spinlogside_titles.push_back("#varphi");
+        std::vector<std::string> spinsideb_titles;
+        std::vector<std::string> spinsidey_titles;
+        spinsideb_titles.push_back("R_{L}");
+        spinsideb_titles.push_back("#varphi_{B}");
+        spinsidey_titles.push_back("R_{L}");
+        spinsidey_titles.push_back("#varphi_{Y}");
 
         // 2D histogram definitions
         std::vector<Histogram> def_2d;
         def_2d.push_back(
-          Histogram("EECPhiVsRStat", "", spinside_titles, spinside_bins)
+          Histogram("EECPhiBlueVsRStat", "", spinsideb_titles, spinside_bins)
         );
         def_2d.push_back(
-          Histogram("EECPhiVsLogRStat", "", spinlogside_titles, spinlogside_bins)
+          Histogram("EECPhiYellVsRStat", "", spinsidey_titles, spinside_bins)
         );
 
         // create histograms
@@ -292,7 +298,6 @@ namespace PHEnergyCorrelator {
         // names of EEC hists to set variances of
         std::vector<std::string> to_set;
         to_set.push_back( "EECWidth" );
-        to_set.push_back( "LogEECWidth" );
 
         for (std::size_t index = 0; index < m_index_tags.size(); ++index) {
           for (std::size_t iset = 0; iset < to_set.size(); ++iset) {
@@ -398,14 +403,17 @@ namespace PHEnergyCorrelator {
         // fill 1d histograms
         m_hist_1d[MakeHistName("EECStat", tag)] -> Fill(content.rl, content.weight);
         m_hist_1d[MakeHistName("EECWidth", tag)] -> Fill(content.rl, content.weight);
-        m_hist_1d[MakeHistName("LogEECStat", tag)] -> Fill(Tools::Log(content.rl), content.weight);
-        m_hist_1d[MakeHistName("LogEECWidth", tag)] -> Fill(Tools::Log(content.rl), content.weight);
         m_hist_1d[MakeHistName("SpinPattern", tag)] -> Fill(content.pattern);
-        m_hist_1d[MakeHistName("SpinPhiStat", tag)] -> Fill(content.phi);
+        m_hist_1d[MakeHistName("SpinPhiBlueStat", tag)] -> Fill(content.phib);
+        m_hist_1d[MakeHistName("SpinPhiYellStat", tag)] -> Fill(content.phiy);
 
         // fill 2d histograms
-        m_hist_2d[MakeHistName("EECPhiVsRStat", tag)] -> Fill(content.rl, content.phi, content.weight);
-        m_hist_2d[MakeHistName("EECPhiVsLogRStat", tag)] -> Fill(Tools::Log(content.rl), content.phi, content.weight);
+        m_hist_2d[MakeHistName("EECPhiBlueVsRStat", tag)] -> Fill(
+          content.rl, content.phib, content.weight
+        );
+        m_hist_2d[MakeHistName("EECPhiYellVsRStat", tag)] -> Fill(
+          content.rl, content.phiy, content.weight
+        );
         return;
 
       }  // end 'FillEECHists(Type::HistIndex&, Type::HistContent&)'
@@ -506,7 +514,7 @@ namespace PHEnergyCorrelator {
         m_do_sp_bins  = false;
         m_nbins_pt    = 1;
         m_nbins_cf    = 1;
-        m_nbins_sp    = 5;
+        m_nbins_sp    = 9;
         m_hist_tag    = "";
         m_hist_pref   = "";
 
@@ -530,7 +538,7 @@ namespace PHEnergyCorrelator {
         m_do_sp_bins  = false;
         m_nbins_pt    = 1;
         m_nbins_cf    = 1;
-        m_nbins_sp    = 5;
+        m_nbins_sp    = 9;
         m_hist_tag    = "";
         m_hist_pref   = "";
 

--- a/include/PHCorrelatorManager.h
+++ b/include/PHCorrelatorManager.h
@@ -47,6 +47,26 @@ namespace PHEnergyCorrelator {
   // ==========================================================================
   class Manager {
 
+    public:
+
+      // ----------------------------------------------------------------------
+      //! Indices of spin configurations
+      // ----------------------------------------------------------------------
+      /*! This enum indexes all possible spin configurations.
+       *  They are
+       *
+       *    0. Int:  integrated over spin
+       *    1. BU:   blue up (int. over yellow)
+       *    2. BD:   blue down (int. over yellow)
+       *    3. YU:   yellow up (int. over blue)
+       *    4. YD:   yellow down (int. over blue)
+       *    5. BUYU: blue up, yellow up
+       *    6. BUYD: blue up, yellow down
+       *    7. BDYU: blue down, yellow up
+       *    8. BDYD: blue down, yellow down
+       */
+      enum Spin {Int, BU, BD, YU, YD, BUYU, BUYD, BDYU, BDYD}; 
+
     private:
 
       /* TODO
@@ -83,24 +103,27 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       //! Translate spin index into a tag
       // ----------------------------------------------------------------------
+      /*! Spin "bins" correspond to different combinations of
+       *  blue/yellow polarizations.
+       */ 
       std::string GetSpinTag(const std::size_t isp) const {
 
         std::string tag = "";
         switch (isp) {
-          case 0:
+          case Int:
+            tag = "Int";
+            break;
+          case BU:
             tag = "BlueUp";
             break;
-          case 1:
+          case BD:
             tag = "BlueDown";
             break;
-          case 2:
+          case YU:
             tag = "YellUp";
             break;
-          case 3:
+          case YD:
             tag = "YellDown";
-            break;
-          case 4:
-            tag = "Integrated";
             break;
           default:
             tag = "";

--- a/include/PHCorrelatorTools.h
+++ b/include/PHCorrelatorTools.h
@@ -235,6 +235,68 @@ namespace PHEnergyCorrelator {
 
     }  // end 'GetWeightedAvgVector(TVector3& x 2)'
 
+
+
+    // ------------------------------------------------------------------------
+    //! Get spins based on a provided spin pattern
+    // ------------------------------------------------------------------------
+    /*! Returns a pair of spin vectors based on a provided spin pattern.
+     *  The 1st element will always be the blue spin, and the 2nd the
+     *  yellow.
+     */
+    std::pair<TVector3, TVector3> GetSpins(const int pattern) { 
+
+      TVector3 blue(0.0, 0.0, 0.0);
+      TVector3 yellow(0.0, 0.0, 0.0);
+      switch (pattern) {
+
+        // blue up, yellow up (pp)
+        case Type::PPBUYU:
+          blue   = Const::SpinUp();
+          yellow = Const::SpinUp();
+          break;
+
+        // blue down, yellow up (pp)
+        case Type::PPBDYU:
+          blue   = Const::SpinDown();
+          yellow = Const::SpinUp();
+          break;
+
+        // blue up, yellow down (pp)
+        case Type::PPBUYD:
+          blue   = Const::SpinUp();
+          yellow = Const::SpinDown();
+          break;
+
+        // blue down, yellow down (pp)
+        case Type::PPBDYD:
+          blue   = Const::SpinDown();
+          yellow = Const::SpinDown();
+          break;
+
+        // blue up (pAu)
+        case Type::PABU:
+          blue   = Const::SpinUp();
+          yellow = Const::SpinNull();
+          break;
+
+        // blue down (pAu)
+        case Type::PABD:
+          blue   = Const::SpinDown();
+          yellow = Const::SpinNull();
+          break;
+
+        // by default, return both as null vectors
+        default:
+          blue   = Const::SpinNull();
+          yellow = Const::SpinNull();
+          break;
+
+      }
+      return std::make_pair(blue, yellow);
+
+    }  // end 'GetSpins(int)'
+
   }  // end Tools namespace
 }  // end PHEnergyCorrelator namespace
 

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -140,17 +140,23 @@ namespace PHEnergyCorrelator {
     // ------------------------------------------------------------------------
     //! Histogram content
     // ------------------------------------------------------------------------
+    /*! FIXME need to add multiple angles wrt spin
+     *    - angle b/n spin and hadron-hadron plane
+     *    - angle b/n spin and combined hadron-hadron + jet plane
+     *      (i.e. the Collins angle)
+     */
     struct HistContent {
 
       // data members
-      double weight;
-      double rl;
-      double rm;
-      double rs;
-      double xi;
-      double theta;
-      double phi;
-      int    pattern;
+      double weight;   //!< energy weight
+      double rl;       //!< longest side length
+      double rm;       //!< medium side length (for E3C)
+      double rs;       //!< shortest side length (for E3C and greater)
+      double xi;       //!< \f$ R_{s} / R_{m} \f$ (for E3C)
+      double theta;    //!< \f$ asin \sqrt(1-\frac{(R_{l}-R_{m})^{2}}{R_{s}^{2}}) \f$ (for E3C)
+      double phib;     //!< angle wrt blue spin
+      double phiy;     //!< angle wrt yellow spin
+      int    pattern;  //!< spin pattern
 
       //! default ctor/dtor
       HistContent()  {};
@@ -160,12 +166,14 @@ namespace PHEnergyCorrelator {
       HistContent(
         const double w,
         const double l,
-        const double f = 0.,
+        const double b = 0.,
+        const double y = 0.,
         const int    p = 0
       ) {
         weight  = w;
         rl      = l;
-        phi     = f;
+        phib    = b;
+        phiy    = y;
         pattern = p;
       }  // end ctor(double x 3, int)
 
@@ -194,7 +202,8 @@ namespace PHEnergyCorrelator {
         const double s,
         const double x,
         const double t,
-        const double f = 0.,
+        const double b = 0.,
+        const double y = 0.,
         const int    p = 0
       ) {
         weight  = w;
@@ -203,7 +212,8 @@ namespace PHEnergyCorrelator {
         rs      = s;
         xi      = x;
         theta   = t;
-        phi     = f;
+        phib    = b;
+        phiy    = y;
         pattern = p;
       }  // end ctor(double x 7, int x 1)
 

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -42,8 +42,6 @@ namespace PHEnergyCorrelator {
       double pt;
       double eta;
       double phi;
-      double phiblu;
-      double phiyel;
       int    pattern;
 
       //! default ctor/dtor
@@ -56,16 +54,12 @@ namespace PHEnergyCorrelator {
         const double parg,
         const double harg,
         const double farg,
-        const double fbarg = 0.,
-        const double fyarg = 0.,
         const int    aarg  = 0
       ) {
         cf      = carg;
         pt      = parg;
         eta     = harg;
         phi     = farg;
-        phiblu  = fbarg;
-        phiyel  = fyarg;
         pattern = aarg; 
       };
 
@@ -140,11 +134,6 @@ namespace PHEnergyCorrelator {
     // ------------------------------------------------------------------------
     //! Histogram content
     // ------------------------------------------------------------------------
-    /*! FIXME need to add multiple angles wrt spin
-     *    - angle b/n spin and hadron-hadron plane
-     *    - angle b/n spin and combined hadron-hadron + jet plane
-     *      (i.e. the Collins angle)
-     */
     struct HistContent {
 
       // data members
@@ -152,10 +141,12 @@ namespace PHEnergyCorrelator {
       double rl;       //!< longest side length
       double rm;       //!< medium side length (for E3C)
       double rs;       //!< shortest side length (for E3C and greater)
-      double xi;       //!< \f$ R_{s} / R_{m} \f$ (for E3C)
-      double theta;    //!< \f$ asin \sqrt(1-\frac{(R_{l}-R_{m})^{2}}{R_{s}^{2}}) \f$ (for E3C)
-      double phib;     //!< angle wrt blue spin
-      double phiy;     //!< angle wrt yellow spin
+      double xi;       //!< \f$R_{s}/R_{m}\f$ (for E3C)
+      double theta;    //!< \f$asin\sqrt(1-\frac{(R_{l}-R_{m})^{2}}{R_{s}^{2}})\f$ (for E3C)
+      double phiHAvgB; //!< hadron-hadron angle wrt blue spin
+      double phiHAvgY; //!< hadron-hadron angle wrt yellow spin
+      double phiCollB; //!< collins (hadron-hadron-jet) angle wrt blue spin
+      double phiCollY; //!< collins (hadron-hadron-jet) angle wrt yellow spin
       int    pattern;  //!< spin pattern
 
       //! default ctor/dtor
@@ -166,16 +157,20 @@ namespace PHEnergyCorrelator {
       HistContent(
         const double w,
         const double l,
-        const double b = 0.,
-        const double y = 0.,
+        const double ab = 0.,
+        const double ay = 0.,
+        const double cb = 0.,
+        const double cy = 0.,
         const int    p = 0
       ) {
-        weight  = w;
-        rl      = l;
-        phib    = b;
-        phiy    = y;
-        pattern = p;
-      }  // end ctor(double x 3, int)
+        weight   = w;
+        rl       = l;
+        phiHAvgB = ab;
+        phiHAvgY = ay;
+        phiCollB = cb;
+        phiCollY = cy;
+        pattern  = p;
+      }  // end ctor(double x 6, int)
 
       //! ctor accepting only 3-point arguments
       HistContent(
@@ -202,20 +197,24 @@ namespace PHEnergyCorrelator {
         const double s,
         const double x,
         const double t,
-        const double b = 0.,
-        const double y = 0.,
+        const double ab = 0.,
+        const double ay = 0.,
+        const double cb = 0.,
+        const double cy = 0.,
         const int    p = 0
       ) {
-        weight  = w;
-        rl      = l;
-        rm      = m;
-        rs      = s;
-        xi      = x;
-        theta   = t;
-        phib    = b;
-        phiy    = y;
-        pattern = p;
-      }  // end ctor(double x 7, int x 1)
+        weight   = w;
+        rl       = l;
+        rm       = m;
+        rs       = s;
+        xi       = x;
+        theta    = t;
+        phiHAvgB = ab;
+        phiHAvgY = ay;
+        phiCollB = cb;
+        phiCollY = cy;
+        pattern  = p;
+      }  // end ctor(double x 9, int x 1)
 
     };  // end HistContent
 

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -28,8 +28,23 @@ namespace PHEnergyCorrelator {
     // ------------------------------------------------------------------------
     //! Weight types
     // ------------------------------------------------------------------------
-    enum Weight {E, Et, Pt};
+    enum Weight {
+      E,   /*!< weight by energy */
+      Et,  /*!< weight by transverse energy */
+      Pt   /*!< weight by transverse momentum (lab frame) */
+    };
 
+    // ----------------------------------------------------------------------
+    //! Possible spin patterns
+    // ----------------------------------------------------------------------
+    enum Pattern {
+      PPBUYU = 0,  /*!< blue up, yellow up (pp) */
+      PPBDYU = 1,  /*!< blue down, yellow up (pp) */
+      PPBUYD = 2,  /*!< blue up, yellow down (pp) */
+      PPBDYD = 3,  /*!< blue down, yellow down (pp) */
+      PABU   = 4,  /*!< blue up (pAu) */
+      PABD   = 5   /*!< blue down (pAu) */
+    };
 
 
     // ------------------------------------------------------------------------

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -162,6 +162,8 @@ namespace PHEnergyCorrelator {
       double phiHAvgY; //!< hadron-hadron angle wrt yellow spin
       double phiCollB; //!< collins (hadron-hadron-jet) angle wrt blue spin
       double phiCollY; //!< collins (hadron-hadron-jet) angle wrt yellow spin
+      double spinB;    //!< blue spin y-component
+      double spinY;    //!< yellow spin y-component
       int    pattern;  //!< spin pattern
 
       //! default ctor/dtor
@@ -176,6 +178,8 @@ namespace PHEnergyCorrelator {
         const double ay = 0.,
         const double cb = 0.,
         const double cy = 0.,
+        const double sb = 0.,
+        const double sy = 0.,
         const int    p = 0
       ) {
         weight   = w;
@@ -184,8 +188,10 @@ namespace PHEnergyCorrelator {
         phiHAvgY = ay;
         phiCollB = cb;
         phiCollY = cy;
+        spinB    = sb;
+        spinY    = sy;
         pattern  = p;
-      }  // end ctor(double x 6, int)
+      }  // end ctor(double x 8, int)
 
       //! ctor accepting only 3-point arguments
       HistContent(
@@ -216,6 +222,8 @@ namespace PHEnergyCorrelator {
         const double ay = 0.,
         const double cb = 0.,
         const double cy = 0.,
+        const double sb = 0.,
+        const double sy = 0.,
         const int    p = 0
       ) {
         weight   = w;
@@ -228,8 +236,10 @@ namespace PHEnergyCorrelator {
         phiHAvgY = ay;
         phiCollB = cb;
         phiCollY = cy;
+        spinB    = sb;
+        spinY    = sy;
         pattern  = p;
-      }  // end ctor(double x 9, int x 1)
+      }  // end ctor(double x 11, int x 1)
 
     };  // end HistContent
 

--- a/include/PHCorrelatorTypes.h
+++ b/include/PHCorrelatorTypes.h
@@ -11,6 +11,9 @@
 #ifndef PHCORRELATORTYPES_H
 #define PHCORRELATORTYPES_H
 
+// analysis components
+#include "PHCorrelatorConstants.h"
+
 
 
 namespace PHEnergyCorrelator {
@@ -69,7 +72,7 @@ namespace PHEnergyCorrelator {
         const double parg,
         const double harg,
         const double farg,
-        const int    aarg  = 0
+        const int    aarg = Const::IntDefault()
       ) {
         cf      = carg;
         pt      = parg;
@@ -134,8 +137,8 @@ namespace PHEnergyCorrelator {
       //! ctor accepting arguments
       HistIndex(
         const std::size_t ipt,
-        const std::size_t icf = 0,
-        const std::size_t isp = 0
+        const std::size_t icf = Const::IndexDefault(),
+        const std::size_t isp = Const::IndexDefault()
       ) {
         pt   = ipt;
         cf   = icf;
@@ -174,13 +177,13 @@ namespace PHEnergyCorrelator {
       HistContent(
         const double w,
         const double l,
-        const double ab = 0.,
-        const double ay = 0.,
-        const double cb = 0.,
-        const double cy = 0.,
-        const double sb = 0.,
-        const double sy = 0.,
-        const int    p = 0
+        const double ab = Const::DoubleDefault(),
+        const double ay = Const::DoubleDefault(),
+        const double cb = Const::DoubleDefault(),
+        const double cy = Const::DoubleDefault(),
+        const double sb = Const::DoubleDefault(),
+        const double sy = Const::DoubleDefault(),
+        const int    p = Const::IntDefault()
       ) {
         weight   = w;
         rl       = l;
@@ -199,8 +202,8 @@ namespace PHEnergyCorrelator {
         const double x,
         const double t,
         const double l,
-        const double m = 0.,
-        const double s = 0.
+        const double m = Const::DoubleDefault(),
+        const double s = Const::DoubleDefault()
       ) {
         weight = w;
         xi     = x;
@@ -218,13 +221,13 @@ namespace PHEnergyCorrelator {
         const double s,
         const double x,
         const double t,
-        const double ab = 0.,
-        const double ay = 0.,
-        const double cb = 0.,
-        const double cy = 0.,
-        const double sb = 0.,
-        const double sy = 0.,
-        const int    p = 0
+        const double ab = Const::DoubleDefault(),
+        const double ay = Const::DoubleDefault(),
+        const double cb = Const::DoubleDefault(),
+        const double cy = Const::DoubleDefault(),
+        const double sb = Const::DoubleDefault(),
+        const double sy = Const::DoubleDefault(),
+        const int    p = Const::IntDefault()
       ) {
         weight   = w;
         rl       = l;

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -91,25 +91,25 @@ void PHEnergyCorrelatorTest() {
   // jet values (enough to cover all spin patterns)
   std::vector<PHEC::Type::Jet> jets;
   jets.push_back(
-    PHEC::Type::Jet(0.40, 9.0, 0.75, piDiv3, piDiv4, pi5Div4, 0)
+    PHEC::Type::Jet(0.40, 9.0, 0.75, piDiv3, 0)
   );
   jets.push_back(
-    PHEC::Type::Jet(0.25, 8.0, 0.2, piDiv4, piDiv3, pi5Div4, 1)
+    PHEC::Type::Jet(0.25, 8.0, 0.2, piDiv4, 1)
   );
   jets.push_back(
-    PHEC::Type::Jet(0.75, 13., -0.2, pi5Div4, piDiv3, pi5Div4, 2)
+    PHEC::Type::Jet(0.75, 13., -0.2, pi5Div4, 2)
   );
   jets.push_back(
-    PHEC::Type::Jet(0.90, 5.0, 0.1, piDiv3, pi5Div4, piDiv4, 3)
+    PHEC::Type::Jet(0.90, 5.0, 0.1, piDiv3, 3)
   );
   jets.push_back(
-    PHEC::Type::Jet(1.0, 7.0, -0.05, pi4Div3, piDiv4, pi5Div4, 4)
+    PHEC::Type::Jet(1.0, 7.0, -0.05, pi4Div3, 4)
   );
   jets.push_back(
-    PHEC::Type::Jet(0.50, 3.0, -0.75, pi4Div3, pi5Div4, piDiv3, 5)
+    PHEC::Type::Jet(0.50, 3.0, -0.75, pi4Div3, 5)
   );
   jets.push_back(
-    PHEC::Type::Jet(0.66, 4.0, -0.05, pi4Div3, piDiv4, pi5Div4, 6)
+    PHEC::Type::Jet(0.66, 4.0, -0.05, pi4Div3, 6)
   );
 
   // cst values (enough to make sure calculations run)

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -91,7 +91,7 @@ void PHEnergyCorrelatorTest() {
   // jet values (enough to cover all spin patterns)
   std::vector<PHEC::Type::Jet> jets;
   jets.push_back(
-    PHEC::Type::Jet(2.0, 9.0, 0.75, piDiv3, piDiv4, pi5Div4, 0)
+    PHEC::Type::Jet(0.40, 9.0, 0.75, piDiv3, piDiv4, pi5Div4, 0)
   );
   jets.push_back(
     PHEC::Type::Jet(0.25, 8.0, 0.2, piDiv4, piDiv3, pi5Div4, 1)
@@ -100,16 +100,16 @@ void PHEnergyCorrelatorTest() {
     PHEC::Type::Jet(0.75, 13., -0.2, pi5Div4, piDiv3, pi5Div4, 2)
   );
   jets.push_back(
-    PHEC::Type::Jet(1.50, 5.0, 0.1, piDiv3, piDiv4, pi5Div4, 3)
+    PHEC::Type::Jet(0.90, 5.0, 0.1, piDiv3, pi5Div4, piDiv4, 3)
   );
   jets.push_back(
     PHEC::Type::Jet(1.0, 7.0, -0.05, pi4Div3, piDiv4, pi5Div4, 4)
   );
   jets.push_back(
-    PHEC::Type::Jet(0.50, 3.0, -0.75, pi4Div3, piDiv4, pi5Div4, 5)
+    PHEC::Type::Jet(0.50, 3.0, -0.75, pi4Div3, pi5Div4, piDiv3, 5)
   );
   jets.push_back(
-    PHEC::Type::Jet(1.0, 4.0, -0.05, pi4Div3, piDiv4, pi5Div4, 6)
+    PHEC::Type::Jet(0.66, 4.0, -0.05, pi4Div3, piDiv4, pi5Div4, 6)
   );
 
   // cst values (enough to make sure calculations run)


### PR DESCRIPTION
This PR extends the spin sorting and histogramming to (1) include both 1-beam (e.g. blue up and int. over yellow) and 2-beam bins (e.g. blue up and yellow down), (2) cover both pp and pAu systems, and (3) correctly calculate the angle with respect to spin in two different approaches.

## Changes
- [x] Extend spin bins to include 2-beam bins
- [x] Extend spin pattern parsing to work for pp and pAu cases
- [x] Make indexing less bug-prone with enums
- [x] Add histograms, content fields for both spin-hadron-hadron and spin-jet-hadron-hadron angles
- [x] Fix hadron-hadron angle calculation and add spin-jet-hadron-hadron angle calculations