### PR TITLE
Fix angular binning and constituent charges

### DIFF
--- a/include/PHCorrelatorBins.h
+++ b/include/PHCorrelatorBins.h
@@ -94,7 +94,7 @@ namespace PHEnergyCorrelator {
         m_bins["energy"]   = Binning(202, -1., 100.);
         m_bins["side"]     = Binning(75, 1e-5, 1., Type::Log);
         m_bins["logside"]  = Binning(75, -5., 0.);
-        m_bins["angle"]    = Binning(180, -3.15, 3.15);
+        m_bins["angle"]    = Binning(45, -3.15, 3.15);
         m_bins["cosangle"] = Binning(20, -1., 1.);
         m_bins["xi"]       = Binning(100, 0., 1.);
         m_bins["pattern"]  = Binning(10, -0.5, 9.5);

--- a/test/jetAna.C
+++ b/test/jetAna.C
@@ -1102,11 +1102,22 @@ void jetAna(int RUNNUM = 12, int isHI = 0, float R = 0.3, float centLow = 0.0, f
                 iCstA < re_cs_z->at(indexMax).size();
                 ++iCstA
               ) {
+
+                // keep only charged csts.s
+                if (re_cs_charge->at(indexMax).at(iCstA) == 0.0) {
+                  continue;
+                }
+
                 for (
                   std::size_t iCstB = 0;
                   iCstB < re_cs_z->at(indexMax).size();
                   ++iCstB
                 ) {
+
+                  // keep only charged csts.s
+                  if (re_cs_charge->at(indexMax).at(iCstB) == 0.0) {
+                    continue;
+                  }
 
                   // collect cst information into a handy struct
                   PHEC::Type::Cst cstA(

--- a/test/jetAnaSim.C
+++ b/test/jetAnaSim.C
@@ -2208,11 +2208,22 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
                     iTruthCstA < tr_cs_z->at(max_truth_idx).size();
                     ++iTruthCstA
                   ) {
+
+                    // keep only charged cst.s
+                    if (tr_cs_charge->at(indexMax).at(iTruthCstA) == 0.0) {
+                      continue;
+                    }
+
                     for (
                       std::size_t iTruthCstB = 0;
                       iTruthCstB < tr_cs_z->at(max_truth_idx).size();
                       ++iTruthCstB
                     ) {
+
+                      // keep only charged cst.s
+                      if (tr_cs_charge->at(indexMax).at(iTruthCstA) == 0.0) {
+                        continue;
+                      }
 
                       // collect cst information into a handy struct
                       PHEC::Type::Cst cstA(
@@ -2262,11 +2273,22 @@ void jetAnaSim(int runno=12, float R = 0.3, int embed = 0, float centLow = 0.0, 
                     iRecoCstA < re_cs_z->at(indexMax).size();
                     ++iRecoCstA
                   ) {
+
+                    // keep only charged cst.s
+                    if (re_cs_charge->at(indexMax).at(iRecoCstA) == 0.0) {
+                      continue;
+                    }
+
                     for (
                       std::size_t iRecoCstB = 0;
                       iRecoCstB < re_cs_z->at(indexMax).size();
                       ++iRecoCstB
                     ) {
+
+                      // keep only charged cst.s
+                      if (re_cs_charge->at(indexMax).at(iRecoCstB) == 0.0) {
+                        continue;
+                      }
 
                       // collect cst information into a handy struct
                       PHEC::Type::Cst cstA(


### PR DESCRIPTION
This PR makes two minor tweaks to the analysis code:

- Angular binning (for the spin angles, e.g.) is now 4x as coarse, and
- Now only charged constituents are considered for the EEC calculation.