### PR TITLE
Fix issue with duplicating histograms

### DIFF
--- a/include/PHCorrelatorHistManager.h
+++ b/include/PHCorrelatorHistManager.h
@@ -299,7 +299,7 @@ namespace PHEnergyCorrelator {
       void GenerateIndexTags() {
 
         // set n bins for pt & charge
-        //   - n.b. once more, the these will have 1 additional "bin",
+        //   - n.b. once more, these will have 1 additional "bin",
         //     for integration
         const std::size_t nbins_pt_use = m_nbins_pt + 1;
         const std::size_t nbins_ch_use = m_nbins_ch + 1;

--- a/include/PHCorrelatorHistManager.h
+++ b/include/PHCorrelatorHistManager.h
@@ -276,15 +276,12 @@ namespace PHEnergyCorrelator {
             switch (dim) {
               case 1:
                 m_hist_1d[ HashString(hist.GetName().data()) ] = hist.MakeTH1();
-                m_hist_1d[ HashString(hist.GetName().data()) ] -> Sumw2();
                 break;
               case 2:
                 m_hist_2d[ HashString(hist.GetName().data()) ] = hist.MakeTH2();
-                m_hist_2d[ HashString(hist.GetName().data()) ] -> Sumw2();
                 break;
               case 3:
                 m_hist_3d[ HashString(hist.GetName().data()) ] = hist.MakeTH3();
-                m_hist_3d[ HashString(hist.GetName().data()) ] -> Sumw2();
                 break;
               default:
                 assert((dim >= 1) && (dim <= 3));
@@ -517,6 +514,11 @@ namespace PHEnergyCorrelator {
         // then create tags for each bin and histogrma prefixes
         GenerateIndexTags();
         GenerateHistPrefix();
+
+        // turn on errors ahead of hist generation
+        TH1::SetDefaultSumw2(true);
+        TH2::SetDefaultSumw2(true);
+        TH3::SetDefaultSumw2(true);
 
         // finally generate appropriate histograms
         //   - TODO add others when ready

--- a/include/PHCorrelatorHistManager.h
+++ b/include/PHCorrelatorHistManager.h
@@ -298,13 +298,17 @@ namespace PHEnergyCorrelator {
       // ----------------------------------------------------------------------
       void GenerateIndexTags() {
 
+        // set n bins for pt & charge
+        //   - n.b. once more, the these will have 1 additional "bin",
+        //     for integration
+        const std::size_t nbins_pt_use = m_nbins_pt + 1;
+        const std::size_t nbins_ch_use = m_nbins_ch + 1;
+
         // build list of indices
-        //   - n.b. the pt and charge bins will have 1 additional "bin",
-        //     corresponding to integrating over pt or charge
         std::vector<Type::HistIndex> indices;
-        for (std::size_t ipt = 0; ipt < m_nbins_pt + 1; ++ipt) {
+        for (std::size_t ipt = 0; ipt < nbins_pt_use; ++ipt) {
           for (std::size_t icf = 0; icf < m_nbins_cf; ++icf) {
-            for (std::size_t ich = 0; ich < m_nbins_ch + 1; ++ich) {
+            for (std::size_t ich = 0; ich < nbins_ch_use; ++ich) {
               for (std::size_t isp = 0; isp < m_nbins_sp; ++isp) {
                 indices.push_back( Type::HistIndex(ipt, icf, ich, isp) );
               }
@@ -506,9 +510,11 @@ namespace PHEnergyCorrelator {
       void GenerateHists() {
 
         // 1st make sure there'll be at least 1 index
-        m_nbins_pt = m_do_pt_bins ? m_nbins_pt : (std::size_t) 1;
+        //   - n.b. as always, not that pt and chrg will add one
+        //     "bin" for integration
+        m_nbins_pt = m_do_pt_bins ? m_nbins_pt : (std::size_t) 0;
         m_nbins_cf = m_do_cf_bins ? m_nbins_cf : (std::size_t) 1;
-        m_nbins_ch = m_do_ch_bins ? m_nbins_ch : (std::size_t) 1;
+        m_nbins_ch = m_do_ch_bins ? m_nbins_ch : (std::size_t) 0;
         m_nbins_sp = m_do_sp_bins ? m_nbins_sp : (std::size_t) 1;
 
         // then create tags for each bin and histogrma prefixes
@@ -658,9 +664,9 @@ namespace PHEnergyCorrelator {
         m_do_cf_bins  = false;
         m_do_ch_bins  = false;
         m_do_sp_bins  = false;
-        m_nbins_pt    = 1;
+        m_nbins_pt    = 0;  // n.b. there will always be 1 additional integrated "bin"
         m_nbins_cf    = 1;
-        m_nbins_ch    = 1;
+        m_nbins_ch    = 0;  // n.b. there will always be 1 additional integrated "bin"
         m_nbins_sp    = 9;
         m_hist_tag    = "";
         m_hist_pref   = "";
@@ -684,9 +690,9 @@ namespace PHEnergyCorrelator {
         m_do_cf_bins  = false;
         m_do_ch_bins  = false;
         m_do_sp_bins  = false;
-        m_nbins_pt    = 1;
+        m_nbins_pt    = 0;  // n.b. there will always be 1 additional integrated "bin"
         m_nbins_cf    = 1;
-        m_nbins_ch    = 1;
+        m_nbins_ch    = 0;  // n.b. there will always be 1 additional integrated "bin"
         m_nbins_sp    = 9;
         m_hist_tag    = "";
         m_hist_pref   = "";

--- a/test/PHEnergyCorrelatorTest.C
+++ b/test/PHEnergyCorrelatorTest.C
@@ -226,9 +226,35 @@ void PHEnergyCorrelatorTest() {
   std::cout << "      --- [PASS] ran third calculation" << std::endl;
 
   // --------------------------------------------------------------------------
+  // Test turning off CF and charge binning
+  // --------------------------------------------------------------------------
+  std::cout << "    Case [5]: test no CF/charge binning" << std::endl;
+
+  // instantiate calculator
+  PHEC::Calculator calc_d(PHEC::Type::Pt);
+  calc_d.SetPtJetBins(ptjetbins);
+  calc_d.SetHistTag("FourthCalculation");
+  calc_d.Init(true);
+
+  // run calculations
+  for (std::size_t ijet = 0; ijet < jets.size(); ++ijet) {
+    for (std::size_t icst_a = 0; icst_a < csts[ijet].size(); ++icst_a) {
+      for (std::size_t icst_b = 0; icst_b < csts[ijet].size(); ++icst_b) {
+
+        // do calculation
+        calc_d.CalcEEC(
+          jets[ijet],
+          std::make_pair(csts[ijet][icst_a], csts[ijet][icst_b])
+        );
+      }
+    }
+  }
+  std::cout << "      --- [PASS] ran fourth calculation" << std::endl;
+
+  // --------------------------------------------------------------------------
   // Save histograms
   // --------------------------------------------------------------------------
-  std::cout << "    Case [5]: test saving histograms" << std::endl;
+  std::cout << "    Case [6]: test saving histograms" << std::endl;
 
   // create output file
   TFile* output = new TFile("test.root", "recreate");
@@ -237,6 +263,7 @@ void PHEnergyCorrelatorTest() {
   calc_a.End(output);
   calc_b.End(output);
   calc_c.End(output);
+  calc_d.End(output);
   std::cout << "      --- [PASS] histograms saved" << std::endl;
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
This PR resolves a bug wherein histograms would be duplicated if charge binning was turned off.

**Details:**
- Previously, the number of `pt` and `charge` bins would be set to 1.
- Then, when the list of index tags to generate was made, the code would create `n_charge_bins + 1` (the additional bin being for the "integrated" bin).
- This means that, by default, _two_ histograms would be generated per `(pt, spin)` (or `(pt, cf, spin)`) bin.
- However, when making a tag, the code only adds the corresponding tag _if_ that binning is turned on. So, again by default, the charge tag would _not_ be added, and you would get two histograms with the same name.
- The fix was to simply set `pt` and `charge` bins to **0 by default**, rather than 1

**Note:** it was also confirmed that the code produces sane behavior when _all_ binning is turned off (including `pt`).