### PR TITLE
Fix ROOT6 warnings, change include path in speed test

### DIFF
--- a/include/PHCorrelatorConstants.h
+++ b/include/PHCorrelatorConstants.h
@@ -83,7 +83,7 @@ namespace PHEnergyCorrelator {
     //! Default value for double arguments
     // ------------------------------------------------------------------------
     inline double DoubleDefault() {
-      const int def = std::numeric_limits<double>::max();
+      const double def = std::numeric_limits<double>::max();
       return def;
     }
 

--- a/test/performance/CorrelatorSpeedTest.C
+++ b/test/performance/CorrelatorSpeedTest.C
@@ -20,7 +20,7 @@
 #include <TRandom3.h>
 #include <TStopwatch.h>
 // analysis header
-#include "../include/PHEnergyCorrelator.h"
+#include "../../include/PHEnergyCorrelator.h"
 
 
 


### PR DESCRIPTION
Testing the code with ROOT6.26 & ROOT6.32 revealed a inconsequential error in `PHCorrelatorConstants.h` where I was an overflowing an `int`.