### PR TITLE
Merge DiFF angle calculation into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so
 *.pcm
 *.root
+ref/
 test/*
 output/
 !test/bins.h

--- a/include/PHCorrelatorAnaTypes.h
+++ b/include/PHCorrelatorAnaTypes.h
@@ -157,19 +157,21 @@ namespace PHEnergyCorrelator {
     struct HistContent {
 
       // data members
-      double weight;   //!< energy weight
-      double rl;       //!< longest side length
-      double rm;       //!< medium side length (for E3C)
-      double rs;       //!< shortest side length (for E3C and greater)
-      double xi;       //!< \f$R_{s}/R_{m}\f$ (for E3C)
-      double theta;    //!< \f$asin\sqrt(1-\frac{(R_{l}-R_{m})^{2}}{R_{s}^{2}})\f$ (for E3C)
-      double phiCollB; //!< blue collins angle: phiSpin - phiHadron
-      double phiCollY; //!< yellow collins angle: phiSpin - phiHadron
-      double phiBoerB; //!< boer-mulders angle: phiSpin - (2*phiHadron)
-      double phiBoerY; //!< boer-mulders angle: phiSpin - (2*phiHadron)
-      double spinB;    //!< blue spin y-component
-      double spinY;    //!< yellow spin y-component
-      int    pattern;  //!< spin pattern
+      double weight;     //!< energy weight
+      double rl;         //!< longest side length
+      double rm;         //!< medium side length (for E3C)
+      double rs;         //!< shortest side length (for E3C and greater)
+      double xi;         //!< \f$R_{s}/R_{m}\f$ (for E3C)
+      double theta;      //!< \f$asin\sqrt(1-\frac{(R_{l}-R_{m})^{2}}{R_{s}^{2}})\f$ (for E3C)
+      double phiCollB;   //!< blue collins angle: phiSpin - phiHadron
+      double phiCollY;   //!< yellow collins angle: phiSpin - phiHadron
+      double phiBoerB;   //!< blue boer-mulders angle: phiSpin - (2*phiHadron)
+      double phiBoerY;   //!< yellow boer-mulders angle: phiSpin - (2*phiHadron)
+      double thSpinRCB;  //!< blue DiFF angle: phiSpin - RC
+      double thSpinRCY;  //!< yellow DiFF angle: phiSpin - RC
+      double spinB;      //!< blue spin y-component
+      double spinY;      //!< yellow spin y-component
+      int    pattern;    //!< spin pattern
 
       //! default ctor/dtor
       HistContent()  {};
@@ -179,24 +181,20 @@ namespace PHEnergyCorrelator {
       HistContent(
         const double w,
         const double l,
-        const double cb = Const::DoubleDefault(),
-        const double cy = Const::DoubleDefault(),
-        const double bb = Const::DoubleDefault(),
-        const double by = Const::DoubleDefault(),
+        const double db = Const::DoubleDefault(),
+        const double dy = Const::DoubleDefault(),
         const double sb = Const::DoubleDefault(),
         const double sy = Const::DoubleDefault(),
         const int    p = Const::IntDefault()
       ) {
-        weight   = w;
-        rl       = l;
-        phiCollB = cb;
-        phiCollY = cy;
-        phiBoerB = bb;
-        phiBoerY = by;
-        spinB    = sb;
-        spinY    = sy;
-        pattern  = p;
-      }  // end ctor(double x 8, int)
+        weight    = w;
+        rl        = l;
+        thSpinRCB = db;
+        thSpinRCY = dy;
+        spinB     = sb;
+        spinY     = sy;
+        pattern   = p;
+      }  // end ctor(double x 7, int)
 
       //! ctor accepting only 3-point arguments
       HistContent(
@@ -227,24 +225,28 @@ namespace PHEnergyCorrelator {
         const double cy = Const::DoubleDefault(),
         const double bb = Const::DoubleDefault(),
         const double by = Const::DoubleDefault(),
+        const double db = Const::DoubleDefault(),
+        const double dy = Const::DoubleDefault(),
         const double sb = Const::DoubleDefault(),
         const double sy = Const::DoubleDefault(),
         const int    p = Const::IntDefault()
       ) {
-        weight   = w;
-        rl       = l;
-        rm       = m;
-        rs       = s;
-        xi       = x;
-        theta    = t;
-        phiCollB = cb;
-        phiCollY = cy;
-        phiBoerB = bb;
-        phiBoerY = by;
-        spinB    = sb;
-        spinY    = sy;
-        pattern  = p;
-      }  // end ctor(double x 11, int x 1)
+        weight    = w;
+        rl        = l;
+        rm        = m;
+        rs        = s;
+        xi        = x;
+        theta     = t;
+        phiCollB  = cb;
+        phiCollY  = cy;
+        phiBoerB  = bb;
+        phiBoerY  = by;
+        thSpinRCB = db;
+        thSpinRCY = dy;
+        spinB     = sb;
+        spinY     = sy;
+        pattern   = p;
+      }  // end ctor(double x 13, int x 1)
 
     };  // end HistContent
 

--- a/include/PHCorrelatorAngler.h
+++ b/include/PHCorrelatorAngler.h
@@ -190,9 +190,9 @@ namespace PHEnergyCorrelator {
         // get thetas (thetaSB, thetaSA)
         //   - by definition, acos only returns values
         //     between [0, pi]
-	//   - so the sign of sintheta will determine if
-	//     angle is in [-pi, 0] or [0, pi]
-	double thetas = (sintheta > 0.0) ? acos(costheta) : -acos(costheta);
+        //   - so the sign of sintheta will determine if
+        //     angle is in [-pi, 0] or [0, pi]
+        double thetas = (sintheta > 0.0) ? acos(costheta) : -acos(costheta);
         if (m_do_wrap) {
           Wrap(thetas);
         }

--- a/include/PHCorrelatorAngler.h
+++ b/include/PHCorrelatorAngler.h
@@ -147,6 +147,60 @@ namespace PHEnergyCorrelator {
       }  // end 'GetBoerMuldersAngle(double, double)'
 
       // ----------------------------------------------------------------------
+      //! Get DiFF spin-beam angle
+      // ----------------------------------------------------------------------
+      /*! Calculates theta_s, angle between spin and the scattering plane, the
+       *  plane defined by the beam and PC (dihadron center-of-mass).  Angle is
+       *  wrapped accordingly based on m_do_wrap and m_wrap.  For more details,
+       *  see arXiv:hep-ph/0409174.
+       *
+       *  \param unit_beam     normalized beam direction (i.e. PB or PA)
+       *  \param vec_spin      spin direction of beam (i.e. SB or SA)
+       *  \param vec_dihad_com dihadron center-of-mass (i.e. PC)
+       */
+      double GetDiFFSpinBeamAngle(
+        const TVector3& unit_beam,
+        const TVector3& vec_spin,
+        const TVector3& vec_dihad_com
+      ) const {
+
+        // calculate cosine of theta_s
+	double costheta = (
+          unit_beam.Cross(vec_dihad_com) * (
+            1.0 / (
+              unit_beam.Cross(vec_dihad_com).Mag()
+            )
+          )
+        ).Dot(
+          unit_beam.Cross(vec_spin) * (
+            1.0 / unit_beam.Cross(vec_spin).Mag()
+          )
+        );
+
+        // calculate sine of theta_s
+	double sintheta = (
+          vec_dihad_com.Cross(vec_spin)
+        ).Dot(unit_beam) * (
+          1.0 / (
+            (unit_beam.Cross(vec_dihad_com).Mag()) *
+            (unit_beam.Cross(vec_spin).Mag())
+          )
+        );
+
+        // get thetas (thetaSB, thetaSA)
+        //   - by definition, acos only returns values
+        //     between [0, pi]
+	//   - so the sign of sintheta will determine if
+	//     angle is in [-pi, 0] or [0, pi]
+	double thetas = (sintheta > 0.0) ? acos(costheta) : -acos(costheta);
+        if (m_do_wrap) {
+          Wrap(thetas);
+        }
+        return thetas;
+
+      }  // end 'GetDiFFSpinBeamAngle(TVector3& x 3)'
+
+      // ----------------------------------------------------------------------
       //! default ctor
       // ----------------------------------------------------------------------
       Angler()  {

--- a/include/PHCorrelatorAngler.h
+++ b/include/PHCorrelatorAngler.h
@@ -147,7 +147,7 @@ namespace PHEnergyCorrelator {
       }  // end 'GetBoerMuldersAngle(double, double)'
 
       // ----------------------------------------------------------------------
-      //! Get DiFF spin-beam angle
+      //! Get DiFF spin-scattering angle
       // ----------------------------------------------------------------------
       /*! Calculates theta_s, angle between spin and the scattering plane, the
        *  plane defined by the beam and PC (dihadron center-of-mass).  Angle is
@@ -158,7 +158,7 @@ namespace PHEnergyCorrelator {
        *  \param vec_spin      spin direction of beam (i.e. SB or SA)
        *  \param vec_dihad_com dihadron center-of-mass (i.e. PC)
        */
-      double GetDiFFSpinBeamAngle(
+      double GetDiFFSpinScatteringAngle(
         const TVector3& unit_beam,
         const TVector3& vec_spin,
         const TVector3& vec_dihad_com
@@ -198,7 +198,63 @@ namespace PHEnergyCorrelator {
         }
         return thetas;
 
-      }  // end 'GetDiFFSpinBeamAngle(TVector3& x 3)'
+      }  // end 'GetDiFFSpinScatteringAngle(TVector3& x 3)'
+
+      // ----------------------------------------------------------------------
+      //! Get DiFF imbalance-scattering plane angle
+      // ----------------------------------------------------------------------
+      /*! Calculates theta_rc, angle between RC (dihadron momentum
+       *  imbalance) and the scattering plane, the plane defined by the
+       *  beam and PC (dihadron center-of-mass).  Angle is wrapped
+       *  accordingly based on m_do_wrap and m_wrap.  For more details,
+       *  see arXiv:hep-ph/0409174.
+       *
+       *  \param vec_beam       beam direction (i.e. PA or PB)
+       *  \param vec_dihad_imb  dihadron momentum imbalance (i.e. RC)
+       *  \param unit_dihad_com normalized direction of dihadron center-of-
+       *                        mass (i.e. PC)
+       */
+      double GetDiFFImbalanceScatteringAngle(
+        const TVector3& vec_beam,
+        const TVector3& vec_dihad_imb,
+        const TVector3& unit_dihad_com
+      ) const {
+
+        // calculate cosine of theta_rc
+	double costheta = (
+          unit_dihad_com.Cross(vec_beam) * (
+            1.0 / (unit_dihad_com.Cross(vec_beam).Mag())
+          )
+        ).Dot(
+          unit_dihad_com.Cross(vec_dihad_imb) * (
+            1.0 / unit_dihad_com.Cross(vec_dihad_imb).Mag()
+          )
+        );
+
+        // calculate sine of theta_rc
+	double sintheta = (
+          vec_beam.Cross(vec_dihad_imb)
+        ).Dot(
+         unit_dihad_com
+        ) * (
+          1.0 / (
+            (unit_dihad_com.Cross(vec_beam).Mag()) *
+            (unit_dihad_com.Cross(vec_dihad_imb).Mag())
+          )
+        );
+
+        // get thetarc
+        //   - by definition, acos only returns values
+        //     between [0, pi]
+        //   - so the sign of sintheta will determine if
+        //     angle is in [-pi, 0] or [0, pi]
+        double thetarc = (sintheta > 0.0) ? acos(costheta) : -acos(costheta);
+        if (m_do_wrap) {
+          Wrap(thetarc);
+        }
+        return thetarc;
+
+      }  // end 'GetDiFFImbalanceScatteringAngle(TVector3& x 3)'
 
       // ----------------------------------------------------------------------
       //! default ctor

--- a/include/PHCorrelatorCalculator.h
+++ b/include/PHCorrelatorCalculator.h
@@ -417,9 +417,11 @@ namespace PHEnergyCorrelator {
         );
 
         // (5) take difference between RC- and spin-scattering angles
-        const double thSpinRCB = thSpinB - thHadRC;
-        const double thSpinRCY = thSpinY - thHadRC;
- 
+        double thSpinRCB = thSpinB - thHadRC;
+        double thSpinRCY = thSpinY - thHadRC;
+        m_angler.Wrap(thSpinRCB);
+        m_angler.Wrap(thSpinRCY);
+
         // calculate eec quantities -------------------------------------------
 
         // get EEC weights

--- a/include/PHCorrelatorConstants.h
+++ b/include/PHCorrelatorConstants.h
@@ -21,8 +21,7 @@
 namespace PHEnergyCorrelator {
 
   // Random generator for null spin vector
-
-  TRandom3 *rand = new TRandom3(); 
+  TRandom3 *rand = new TRandom3();
 
   // ==========================================================================
   //! PHEnergyCorrelator Constants
@@ -169,10 +168,11 @@ namespace PHEnergyCorrelator {
 
     // ------------------------------------------------------------------------
     //! Null spin in lab coordinates
-    // We actually return a random normalized spin in the x-y plane to avoid
-    // problems with the vector calculations.  Since there is in principle no 
-    // spin dependence this should be a valid thing to do. 
     // ------------------------------------------------------------------------
+    /*! We actually return a random normalized spin in the x-y plane to avoid
+     *  problems with the vector calculations.  Since there is in principle no
+     *  spin dependence this should be a valid thing to do.
+     */
     inline TVector3 SpinNull() {
       const TVector3 null(rand->Uniform(), rand->Uniform(), 0.0);
       return null.Unit();

--- a/include/PHCorrelatorHistManager.h
+++ b/include/PHCorrelatorHistManager.h
@@ -341,10 +341,8 @@ namespace PHEnergyCorrelator {
       void GenerateEECHists() {
 
         // 1d spin axis titles
-        const std::string collB_title("#varphi_{B}^{collins}");
-        const std::string collY_title("#varphi_{Y}^{collins}");
-        const std::string boerB_title("#varphi_{B}^{boers-mulder}");
-        const std::string boerY_title("#varphi_{Y}^{boers-mulder}");
+        const std::string diffB_title("#theta_{s_{B}} - #theta_{R_{c}}");
+        const std::string diffY_title("#theta_{s_{Y}} - #theta_{R_{c}}");
 
         // 1d histogram definitions
         std::vector<Histogram> def_1d;
@@ -352,16 +350,10 @@ namespace PHEnergyCorrelator {
           Histogram("EECStat", "", "R_{L}", m_bins.Get("side"))
         );
         def_1d.push_back(
-          Histogram("CollinsBlueStat", "", collB_title, m_bins.Get("angle"))
+          Histogram("DiFFBlueSpinRC", "", diffB_title, m_bins.Get("angle"))
         );
         def_1d.push_back(
-          Histogram("CollinsYellStat", "", collY_title, m_bins.Get("angle"))
-        );
-        def_1d.push_back(
-          Histogram("BoerMuldersBlueStat", "", boerB_title, m_bins.Get("angle"))
-        );
-        def_1d.push_back(
-          Histogram("BoerMuldersYellStat", "", boerY_title, m_bins.Get("angle"))
+          Histogram("DiFFYellSpinRC", "", diffY_title, m_bins.Get("angle"))
         );
 
         // vectors of binnings for 2d histograms
@@ -370,32 +362,20 @@ namespace PHEnergyCorrelator {
         angleXside_bins.push_back(m_bins.Get("angle"));
 
         // vectors of axis titles for 2d histograms
-        std::vector<std::string> collXsideB_titles;
-        std::vector<std::string> collXsideY_titles;
-        std::vector<std::string> boerXsideB_titles;
-        std::vector<std::string> boerXsideY_titles;
-        collXsideB_titles.push_back("R_{L}");
-        collXsideB_titles.push_back(collB_title);
-        collXsideY_titles.push_back("R_{L}");
-        collXsideY_titles.push_back(collY_title);
-        boerXsideB_titles.push_back("R_{L}");
-        boerXsideB_titles.push_back(boerB_title);
-        boerXsideY_titles.push_back("R_{L}");
-        boerXsideY_titles.push_back(boerY_title);
+        std::vector<std::string> diffXsideB_titles;
+        std::vector<std::string> diffXsideY_titles;
+        diffXsideB_titles.push_back("R_{L}");
+        diffXsideB_titles.push_back(diffB_title);
+        diffXsideY_titles.push_back("R_{L}");
+        diffXsideY_titles.push_back(diffY_title);
 
         // 2D histogram definitions
         std::vector<Histogram> def_2d;
         def_2d.push_back(
-          Histogram("CollinsBlueVsRStat", "", collXsideB_titles, angleXside_bins)
+          Histogram("DiFFBlueSpinRCVsRStat", "", diffXsideB_titles, angleXside_bins)
         );
         def_2d.push_back(
-          Histogram("CollinsYellVsRStat", "", collXsideY_titles, angleXside_bins)
-        );
-        def_2d.push_back(
-          Histogram("BoerMuldersBlueVsRStat", "", boerXsideB_titles, angleXside_bins)
-        );
-        def_2d.push_back(
-          Histogram("BoerMuldersYellVsRStat", "", boerXsideY_titles, angleXside_bins)
+          Histogram("DiFFYellSpinRCVsRStat", "", diffXsideY_titles, angleXside_bins)
         );
 
         // create histograms
@@ -543,23 +523,15 @@ namespace PHEnergyCorrelator {
 
         // fill 1d histograms
         m_hist_1d[ MakeHashedName("EECStat", tag) ] -> Fill(content.rl, content.weight);
-        m_hist_1d[ MakeHashedName("CollinsBlueStat", tag) ] -> Fill(content.phiCollB);
-        m_hist_1d[ MakeHashedName("CollinsYellStat", tag) ] -> Fill(content.phiCollY);
-        m_hist_1d[ MakeHashedName("BoerMuldersBlueStat", tag) ] -> Fill(content.phiBoerB);
-        m_hist_1d[ MakeHashedName("BoerMuldersYellStat", tag) ] -> Fill(content.phiBoerY);
+        m_hist_1d[ MakeHashedName("DiFFBlueSpinRC", tag) ] -> Fill(content.thSpinRCB);
+        m_hist_1d[ MakeHashedName("DiFFYellSpinRC", tag) ] -> Fill(content.thSpinRCY);
 
         // fill 2d histograms
-        m_hist_2d[ MakeHashedName("CollinsBlueVsRStat", tag) ] -> Fill(
-          content.rl, content.phiCollB, content.weight
+        m_hist_2d[ MakeHashedName("DiFFBlueSpinRCVsRStat", tag) ] -> Fill(
+          content.rl, content.thSpinRCB, content.weight
         );
-        m_hist_2d[ MakeHashedName("CollinsYellVsRStat", tag) ] -> Fill(
-          content.rl, content.phiCollY, content.weight
-        );
-        m_hist_2d[ MakeHashedName("BoerMuldersBlueVsRStat", tag) ] -> Fill(
-          content.rl, content.phiBoerB, content.weight
-        );
-        m_hist_2d[ MakeHashedName("BoerMuldersYellVsRStat", tag) ] -> Fill(
-          content.rl, content.phiBoerY, content.weight
+        m_hist_2d[ MakeHashedName("DiFFYellSpinRCVsRStat", tag) ] -> Fill(
+          content.rl, content.thSpinRCY, content.weight
         );
         return;
 


### PR DESCRIPTION
This PR integrates the DiFF angle calculation from [johnlajoie/PHEnergyCorrelator](https://github.com/johnlajoie/PHEnergyCorrelator) into main.

### Changes
- [x] Add DiFF calculation to the angler, incl.
  - [x] Spin-scattering plane angle calculation
  - [x] RC-scattering plane angle calculation
- [x] Add DiFF angles to histograms/histogram content
- [x] Replace Collins, BM calculation/histograms where necessary
- [x] Replaced Collins/Boer-Mulders calculation with DiFF in EEC calculation